### PR TITLE
fix(migration): make 002 idempotent for pre-ACL legacy databases

### DIFF
--- a/src/lib/db/migrations/002-fix-empty-allowed-lists.js
+++ b/src/lib/db/migrations/002-fix-empty-allowed-lists.js
@@ -2,12 +2,25 @@
 // Before this change, [] meant "all allowed" (no restriction). After the permissions refactor,
 // [] means "none allowed" (block all). Any existing key with "[]" stored was saved under the old
 // semantics and must be treated as NULL (unrestricted) to avoid silently blocking all requests.
+//
+// NOTE: This migration must be idempotent — the columns may not exist yet if migrating from
+// a pre-ACL schema (e.g. 9Router v0.5.x). Migration 003 adds them. Running UPDATE on
+// non-existent columns would crash the entire migration chain.
 export default {
   version: 2,
   name: "fix-empty-allowed-lists",
   up(db) {
-    db.exec(`UPDATE apiKeys SET allowedProviders = NULL WHERE allowedProviders = '[]'`);
-    db.exec(`UPDATE apiKeys SET allowedCombos    = NULL WHERE allowedCombos    = '[]'`);
-    db.exec(`UPDATE apiKeys SET allowedKinds     = NULL WHERE allowedKinds     = '[]'`);
+    const rows = db.all("PRAGMA table_info(apiKeys)");
+    const columns = Array.isArray(rows) ? rows.map((row) => row.name) : [];
+
+    if (columns.includes("allowedProviders")) {
+      db.exec(`UPDATE apiKeys SET allowedProviders = NULL WHERE allowedProviders = '[]'`);
+    }
+    if (columns.includes("allowedCombos")) {
+      db.exec(`UPDATE apiKeys SET allowedCombos    = NULL WHERE allowedCombos    = '[]'`);
+    }
+    if (columns.includes("allowedKinds")) {
+      db.exec(`UPDATE apiKeys SET allowedKinds     = NULL WHERE allowedKinds     = '[]'`);
+    }
   },
 };


### PR DESCRIPTION
## Problem

Migration 002 runs `UPDATE apiKeys SET allowedProviders = NULL WHERE ...` but the columns don't exist yet on legacy databases — migration 003 is the one that adds them.

This crashes the entire migration chain for anyone migrating from **9Router v0.5.x** to VansRouter v0.8.x:

```
SqliteError: no such column: allowedProviders
    at Object.exec (src/lib/db/adapters/betterSqliteAdapter.js:46:47)
    at Object.up (src/lib/db/migrations/002-fix-empty-allowed-lists.js:9:8)
```

## Fix

Check `PRAGMA table_info(apiKeys)` before running each UPDATE, matching the idempotent pattern already used in migration 003. If the column doesn't exist yet, the UPDATE is simply skipped (migration 003 will add it, and the data will already be NULL by default).

## Tested

- Migrated real 9Router v0.5.18 database (29k+ requests, 17 combos, 29 provider connections) to VansRouter v0.8.6
- All combos, connections, usage history, and settings preserved
- DB auto-upgraded schema 1→3 successfully