### PR TITLE
docs: add migration guide, improve docker-compose and env docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,38 +1,86 @@
-# 9Router environment contract
-# This file reflects actual runtime usage in the current codebase.
+# ============================================================
+# VansRouter Environment Configuration
+# ============================================================
+# Copy this file to .env and customize for your deployment:
+#   cp .env.example .env && nano .env
+#
+# For Docker Compose:
+#   docker compose up -d
+#
+# For standalone Docker:
+#   docker run --env-file .env -p 20128:20128 ...
+# ============================================================
 
-# Required
+# --- Required ---
+
+# Secret used to sign JWT authentication tokens.
+# Generate with: openssl rand -hex 32
 JWT_SECRET=change-me-to-a-long-random-secret
-INITIAL_PASSWORD=123456
-DATA_DIR=/var/lib/9router
 
-# Recommended runtime variables
-PORT=3003
+# Initial dashboard password (change after first login).
+INITIAL_PASSWORD=123456
+
+# Directory for SQLite database and runtime data.
+# Docker: keep as /app/data (matches volume mount).
+# Native: use an absolute path like /var/lib/vansrouter
+DATA_DIR=/app/data
+
+# --- Runtime ---
+
+# Port the HTTP server listens on.
+# Must match the left side of your Docker port mapping (-p PORT:PORT).
+PORT=20128
+
+# Node environment. Keep "production" for Docker deployments.
 NODE_ENV=production
 
-# Recommended security and ops variables
-API_KEY_SECRET=endpoint-proxy-api-key-secret
-MACHINE_ID_SALT=endpoint-proxy-salt
-ENABLE_REQUEST_LOGS=false
-OBSERVABILITY_ENABLED=true
-AUTH_COOKIE_SECURE=false
+# --- Security ---
+
+# HMAC secret for API key generation. Change in production to invalidate
+# any keys minted with the default.
+# Generate with: openssl rand -hex 32
+API_KEY_SECRET=change-me-in-production
+
+# Salt for machine ID derivation. Change if you clone a VM/container.
+MACHINE_ID_SALT=
+
+# Require API key for /v1/* endpoints. Set false for local-only setups.
 REQUIRE_API_KEY=false
 
-# Cloud sync variables
-# Must point to this running instance so internal sync jobs can call /api/sync/cloud.
-# Server-side preferred variables:
+# Set true if serving behind HTTPS reverse proxy.
+AUTH_COOKIE_SECURE=false
+
+# --- Observability ---
+
+# Enable detailed request logging (high volume).
+ENABLE_REQUEST_LOGS=false
+
+# Enable internal metrics collection.
+OBSERVABILITY_ENABLED=true
+
+# --- Cloud Sync (Optional) ---
+
+# URL of this instance (used by sync jobs).
 BASE_URL=http://localhost:20128
-CLOUD_URL=https://9router.com
-# Backward-compatible/public variables:
 NEXT_PUBLIC_BASE_URL=http://localhost:20128
+
+# Cloud sync target (leave default unless self-hosting sync server).
+CLOUD_URL=https://9router.com
 NEXT_PUBLIC_CLOUD_URL=https://9router.com
 
-# Optional outbound proxy variables for upstream provider calls
-# Lowercase variants are also supported: http_proxy, https_proxy, all_proxy, no_proxy
+# --- Outbound Proxy (Optional) ---
+
+# Route upstream provider calls through an HTTP/SOCKS proxy.
+# Useful for regions with restricted access to AI provider APIs.
 # HTTP_PROXY=http://127.0.0.1:7890
 # HTTPS_PROXY=http://127.0.0.1:7890
 # ALL_PROXY=socks5://127.0.0.1:7890
 # NO_PROXY=localhost,127.0.0.1
 
-# Currently unused by application runtime (kept as reference)
-# INSTANCE_NAME=9router
+# --- Headroom (Optional) ---
+
+# URL of the Headroom sidecar service.
+# Docker Compose default: http://headroom:8787
+# External: http://host.docker.internal:8787
+HEADROOM_URL=http://headroom:8787
+HEADROOM_PORT=8787

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -70,27 +70,61 @@ docker run -d \
 
 ## Optional Headroom sidecar
 
-The VansRouter image does not bundle Python or Headroom. To use Headroom in Docker, run it as a separate service and point VansRouter at that proxy:
+Headroom is an optional sidecar service for tool-history safety and advanced request processing.
+
+### Option A: Docker Compose (Recommended)
+
+Use the provided `docker-compose.yml`:
+
+```bash
+# Copy and customize environment
+cp .env.example .env
+nano .env
+
+# Start both services
+docker compose up -d
+```
+
+### Option B: Manual Compose
+
+Create your own `docker-compose.yml`:
 
 ```yaml
 services:
   vansrouter:
     image: ghcr.io/Vanszs/VansRouter:latest
+    container_name: vansrouter
+    restart: always
     ports:
       - "20128:20128"
     volumes:
-      - "$HOME/.9router:/app/data"
+      - vansrouter-data:/app/data
+    env_file:
+      - .env
     environment:
       DATA_DIR: /app/data
+      PORT: "20128"
+      HOSTNAME: "0.0.0.0"
+      NODE_ENV: production
       HEADROOM_URL: http://headroom:8787
     depends_on:
       - headroom
 
   headroom:
     image: ghcr.io/chopratejas/headroom:latest
+    container_name: headroom
+    restart: always
     ports:
       - "8787:8787"
+
+volumes:
+  vansrouter-data:
+    name: vansrouter-data
 ```
+
+### Option C: Separate Containers
+
+Run Headroom independently:
 
 In the dashboard, open `Endpoint` → `Token Saver` → `Headroom`, confirm the URL is `http://headroom:8787`, recheck status, then enable Headroom.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,18 @@
+# VansRouter Docker Compose
+# Usage:
+#   1. cp .env.example .env && nano .env
+#   2. docker compose up -d
+#   3. Open http://localhost:20128
+
 services:
   vansrouter:
-    image: ghcr.io/Vanszs/VansRouter:latest
+    image: ghcr.io/vanszs/vansrouter:latest
     container_name: vansrouter
-    restart: always
+    restart: unless-stopped
     ports:
-      - "20128:20128"
+      - "${PORT:-20128}:20128"
     volumes:
-      - 9router-data:/app/data
+      - vansrouter-data:/app/data
     env_file:
       - .env
     environment:
@@ -16,15 +22,22 @@ services:
       NODE_ENV: production
       HEADROOM_URL: http://headroom:8787
     depends_on:
-      - headroom
+      headroom:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:20128/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
 
   headroom:
     image: ghcr.io/chopratejas/headroom:latest
     container_name: headroom
-    restart: always
+    restart: unless-stopped
     ports:
-      - "8787:8787"
+      - "${HEADROOM_PORT:-8787}:8787"
 
 volumes:
-  9router-data:
-    name: 9router-data
+  vansrouter-data:
+    name: vansrouter-data

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,162 @@
+# Migration Guide: 9Router → VansRouter
+
+This guide covers migrating an existing **9Router** (decolua/9router) installation to **VansRouter** with zero downtime and full data preservation.
+
+## What migrates
+
+All data in your 9Router SQLite database transfers automatically:
+
+- **Combos** (model routing configurations)
+- **Provider connections** (API keys, OAuth tokens, account settings)
+- **API keys** (Hermes/other client authentication)
+- **Usage history** (request logs, cost tracking)
+- **Settings** (password, strategies, proxy config)
+
+VansRouter auto-detects the legacy schema and upgrades it on first start.
+
+## Prerequisites
+
+- Docker installed
+- 9Router running (any version) with data at `~/.9router/`
+- VansRouter Docker image: `ghcr.io/vanszs/vansrouter:latest`
+
+## Step 1: Backup
+
+```bash
+# Full backup of 9Router data
+cp -r ~/.9router ~/backup-9router-$(date +%Y%m%d_%H%M%S)
+
+# Backup any config files that reference 9Router
+# (e.g., Hermes Agent config, scripts, cron jobs)
+```
+
+## Step 2: Stop 9Router
+
+```bash
+docker stop 9router
+```
+
+Keep the container (don't `docker rm`) — it serves as your rollback option.
+
+## Step 3: Prepare VansRouter data directory
+
+```bash
+# Create VansRouter data directory
+mkdir -p ~/.vansrouter/
+
+# Copy data from 9Router
+cp -r ~/.9router/db ~/.vansrouter/db
+cp ~/.9router/jwt-secret ~/.vansrouter/jwt-secret
+cp ~/.9router/machine-id ~/.vansrouter/machine-id
+cp -r ~/.9router/auth ~/.vansrouter/auth
+cp -r ~/.9router/mitm ~/.vansrouter/mitm 2>/dev/null || true
+cp -r ~/.9router/runtime ~/.vansrouter/runtime 2>/dev/null || true
+```
+
+## Step 4: Start VansRouter
+
+### Option A: Docker Compose (recommended)
+
+```bash
+# Copy environment template
+cp .env.example .env
+nano .env  # Set JWT_SECRET to match ~/.9router/jwt-secret
+
+# Start
+docker compose up -d
+```
+
+### Option B: Docker run
+
+```bash
+# Read your existing JWT secret
+JWT_SECRET=$(cat ~/.vansrouter/jwt-secret)
+
+docker run -d --name vansrouter --restart unless-stopped \
+  -p 20128:20128 \
+  -v ~/.vansrouter:/app/data \
+  -e PORT=20128 \
+  -e HOSTNAME=0.0.0.0 \
+  -e NODE_ENV=production \
+  -e DATA_DIR=/app/data \
+  -e JWT_SECRET="$JWT_SECRET" \
+  -e API_KEY_SECRET="$JWT_SECRET" \
+  -e REQUIRE_API_KEY=false \
+  ghcr.io/vanszs/vansrouter:latest
+```
+
+## Step 5: Verify
+
+```bash
+# Container running?
+docker ps --filter name=vansrouter
+
+# Dashboard accessible?
+curl -s -o /dev/null -w "%{http_code}" http://localhost:20128/
+# Expected: 200
+
+# Check migration logs
+docker logs vansrouter | grep -E "migrate|backup"
+# Expected: [DB][migrate] App 0.5.x → 0.8.6 | schema 1 → 3 | backup: ...
+
+# API responds?
+API_KEY=$(sqlite3 ~/.vansrouter/db/data.sqlite "SELECT key FROM apiKeys WHERE isActive=1;")
+curl -s -H "Authorization: Bearer $API_KEY" http://localhost:20128/v1/models | python3 -c "import sys,json; d=json.load(sys.stdin); print(f'Models: {len(d.get(\"data\",[]))}')"
+```
+
+Open the dashboard at `http://localhost:20128` and verify:
+- All combos appear with correct model lists
+- Provider connections show correct status
+- Usage history is intact
+
+## Step 6: Update dependent services
+
+If you use **Hermes Agent** or another client:
+
+- **Same port (20128)**: No config changes needed
+- **Different port**: Update `base_url` in your client config
+
+If you have auto-update crons for 9Router:
+
+```bash
+# Disable old 9Router update
+# (method depends on your setup: systemd timer, crontab, or Hermes cron)
+
+# Enable VansRouter auto-update script (example: nightly)
+# See scripts/vansrouter-docker-update.sh
+```
+
+## Rollback
+
+If anything goes wrong:
+
+```bash
+# Stop VansRouter
+docker stop vansrouter
+docker rm vansrouter
+
+# Restart 9Router
+docker start 9router
+```
+
+Your original data in `~/.9router/` is untouched. VansRouter data lives in `~/.vansrouter/`.
+
+## Schema changes during migration
+
+VansRouter applies these automatic migrations on first start:
+
+| Migration | What it does |
+|-----------|-------------|
+| 001-initial | Bootstrap tables (idempotent for existing DBs) |
+| 002-fix-empty-allowed-lists | Convert empty ACL arrays `[]` to NULL (unrestricted) |
+| 003-add-allowed-lists-columns | Add `allowedProviders`, `allowedCombos`, `allowedKinds` columns |
+
+A backup is automatically created at `~/.vansrouter/db/backups/` before migration runs.
+
+## Differences from 9Router
+
+- **Image**: `ghcr.io/vanszs/vansrouter` (not `decolua/9router`)
+- **Data dir**: `~/.vansrouter/` recommended (not `~/.9router/`)
+- **Headroom**: Optional sidecar for tool-history safety (not bundled)
+- **Circuit breaker**: Built-in provider failure tracking (inspired by OmniRoute)
+- **Active development**: Regular updates from upstream 9Router + community


### PR DESCRIPTION
## Changes

### 1. Migration Guide (docs/MIGRATION.md)

Complete guide for migrating from 9Router to VansRouter with zero downtime:
- Prerequisites and backup steps
- Data preparation and directory setup
- Two deployment options (Docker Compose and standalone )
- Verification checklist (container, dashboard, API, logs)
- Rollback instructions
- Schema migration reference table

Written from a real migration of 9Router v0.5.18 → VansRouter v0.8.6 with 29k+ requests, 17 combos, and 29 provider connections.

### 2. Docker Compose Improvements

- Add healthcheck for vansrouter service
- Change restart policy to `unless-stopped` (survives reboots without unwanted auto-start)
- Use named volume `vansrouter-data` instead of anonymous
- Add `env_file` support for easier configuration
- Parameterized port mapping via `${PORT:-20128}`
- Proper `depends_on` with condition

### 3. Environment Template (.env.example)

Rewritten with:
- Organized sections (Required, Runtime, Security, Observability, Cloud Sync, Proxy, Headroom)
- Comments explaining every variable
- Secret generation commands (`openssl rand -hex 32`)
- Default values matching docker-compose.yml
- Headroom configuration included

### 4. DOCKER.md Updates

Restructured the Headroom section into three deployment options:
- **Option A**: Docker Compose (recommended, references `docker-compose.yml`)
- **Option B**: Manual Compose (full YAML reference)
- **Option C**: Separate Containers