### PR TITLE
feat: add circuit breaker UI to provider cards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,38 +1,86 @@
-# 9Router environment contract
-# This file reflects actual runtime usage in the current codebase.
+# ============================================================
+# VansRouter Environment Configuration
+# ============================================================
+# Copy this file to .env and customize for your deployment:
+#   cp .env.example .env && nano .env
+#
+# For Docker Compose:
+#   docker compose up -d
+#
+# For standalone Docker:
+#   docker run --env-file .env -p 20128:20128 ...
+# ============================================================
 
-# Required
+# --- Required ---
+
+# Secret used to sign JWT authentication tokens.
+# Generate with: openssl rand -hex 32
 JWT_SECRET=change-me-to-a-long-random-secret
-INITIAL_PASSWORD=123456
-DATA_DIR=/var/lib/9router
 
-# Recommended runtime variables
-PORT=3003
+# Initial dashboard password (change after first login).
+INITIAL_PASSWORD=123456
+
+# Directory for SQLite database and runtime data.
+# Docker: keep as /app/data (matches volume mount).
+# Native: use an absolute path like /var/lib/vansrouter
+DATA_DIR=/app/data
+
+# --- Runtime ---
+
+# Port the HTTP server listens on.
+# Must match the left side of your Docker port mapping (-p PORT:PORT).
+PORT=20128
+
+# Node environment. Keep "production" for Docker deployments.
 NODE_ENV=production
 
-# Recommended security and ops variables
-API_KEY_SECRET=endpoint-proxy-api-key-secret
-MACHINE_ID_SALT=endpoint-proxy-salt
-ENABLE_REQUEST_LOGS=false
-OBSERVABILITY_ENABLED=true
-AUTH_COOKIE_SECURE=false
+# --- Security ---
+
+# HMAC secret for API key generation. Change in production to invalidate
+# any keys minted with the default.
+# Generate with: openssl rand -hex 32
+API_KEY_SECRET=change-me-in-production
+
+# Salt for machine ID derivation. Change if you clone a VM/container.
+MACHINE_ID_SALT=
+
+# Require API key for /v1/* endpoints. Set false for local-only setups.
 REQUIRE_API_KEY=false
 
-# Cloud sync variables
-# Must point to this running instance so internal sync jobs can call /api/sync/cloud.
-# Server-side preferred variables:
+# Set true if serving behind HTTPS reverse proxy.
+AUTH_COOKIE_SECURE=false
+
+# --- Observability ---
+
+# Enable detailed request logging (high volume).
+ENABLE_REQUEST_LOGS=false
+
+# Enable internal metrics collection.
+OBSERVABILITY_ENABLED=true
+
+# --- Cloud Sync (Optional) ---
+
+# URL of this instance (used by sync jobs).
 BASE_URL=http://localhost:20128
-CLOUD_URL=https://9router.com
-# Backward-compatible/public variables:
 NEXT_PUBLIC_BASE_URL=http://localhost:20128
+
+# Cloud sync target (leave default unless self-hosting sync server).
+CLOUD_URL=https://9router.com
 NEXT_PUBLIC_CLOUD_URL=https://9router.com
 
-# Optional outbound proxy variables for upstream provider calls
-# Lowercase variants are also supported: http_proxy, https_proxy, all_proxy, no_proxy
+# --- Outbound Proxy (Optional) ---
+
+# Route upstream provider calls through an HTTP/SOCKS proxy.
+# Useful for regions with restricted access to AI provider APIs.
 # HTTP_PROXY=http://127.0.0.1:7890
 # HTTPS_PROXY=http://127.0.0.1:7890
 # ALL_PROXY=socks5://127.0.0.1:7890
 # NO_PROXY=localhost,127.0.0.1
 
-# Currently unused by application runtime (kept as reference)
-# INSTANCE_NAME=9router
+# --- Headroom (Optional) ---
+
+# URL of the Headroom sidecar service.
+# Docker Compose default: http://headroom:8787
+# External: http://host.docker.internal:8787
+HEADROOM_URL=http://headroom:8787
+HEADROOM_PORT=8787

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -70,27 +70,61 @@ docker run -d \
 
 ## Optional Headroom sidecar
 
-The VansRouter image does not bundle Python or Headroom. To use Headroom in Docker, run it as a separate service and point VansRouter at that proxy:
+Headroom is an optional sidecar service for tool-history safety and advanced request processing.
+
+### Option A: Docker Compose (Recommended)
+
+Use the provided `docker-compose.yml`:
+
+```bash
+# Copy and customize environment
+cp .env.example .env
+nano .env
+
+# Start both services
+docker compose up -d
+```
+
+### Option B: Manual Compose
+
+Create your own `docker-compose.yml`:
 
 ```yaml
 services:
   vansrouter:
     image: ghcr.io/Vanszs/VansRouter:latest
+    container_name: vansrouter
+    restart: always
     ports:
       - "20128:20128"
     volumes:
-      - "$HOME/.9router:/app/data"
+      - vansrouter-data:/app/data
+    env_file:
+      - .env
     environment:
       DATA_DIR: /app/data
+      PORT: "20128"
+      HOSTNAME: "0.0.0.0"
+      NODE_ENV: production
       HEADROOM_URL: http://headroom:8787
     depends_on:
       - headroom
 
   headroom:
     image: ghcr.io/chopratejas/headroom:latest
+    container_name: headroom
+    restart: always
     ports:
       - "8787:8787"
+
+volumes:
+  vansrouter-data:
+    name: vansrouter-data
 ```
+
+### Option C: Separate Containers
+
+Run Headroom independently:
 
 In the dashboard, open `Endpoint` → `Token Saver` → `Headroom`, confirm the URL is `http://headroom:8787`, recheck status, then enable Headroom.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,18 @@
+# VansRouter Docker Compose
+# Usage:
+#   1. cp .env.example .env && nano .env
+#   2. docker compose up -d
+#   3. Open http://localhost:20128
+
 services:
   vansrouter:
-    image: ghcr.io/Vanszs/VansRouter:latest
+    image: ghcr.io/vanszs/vansrouter:latest
     container_name: vansrouter
-    restart: always
+    restart: unless-stopped
     ports:
-      - "20128:20128"
+      - "${PORT:-20128}:20128"
     volumes:
-      - 9router-data:/app/data
+      - vansrouter-data:/app/data
     env_file:
       - .env
     environment:
@@ -16,15 +22,22 @@ services:
       NODE_ENV: production
       HEADROOM_URL: http://headroom:8787
     depends_on:
-      - headroom
+      headroom:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:20128/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
 
   headroom:
     image: ghcr.io/chopratejas/headroom:latest
     container_name: headroom
-    restart: always
+    restart: unless-stopped
     ports:
-      - "8787:8787"
+      - "${HEADROOM_PORT:-8787}:8787"
 
 volumes:
-  9router-data:
-    name: 9router-data
+  vansrouter-data:
+    name: vansrouter-data

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,162 @@
+# Migration Guide: 9Router → VansRouter
+
+This guide covers migrating an existing **9Router** (decolua/9router) installation to **VansRouter** with zero downtime and full data preservation.
+
+## What migrates
+
+All data in your 9Router SQLite database transfers automatically:
+
+- **Combos** (model routing configurations)
+- **Provider connections** (API keys, OAuth tokens, account settings)
+- **API keys** (Hermes/other client authentication)
+- **Usage history** (request logs, cost tracking)
+- **Settings** (password, strategies, proxy config)
+
+VansRouter auto-detects the legacy schema and upgrades it on first start.
+
+## Prerequisites
+
+- Docker installed
+- 9Router running (any version) with data at `~/.9router/`
+- VansRouter Docker image: `ghcr.io/vanszs/vansrouter:latest`
+
+## Step 1: Backup
+
+```bash
+# Full backup of 9Router data
+cp -r ~/.9router ~/backup-9router-$(date +%Y%m%d_%H%M%S)
+
+# Backup any config files that reference 9Router
+# (e.g., Hermes Agent config, scripts, cron jobs)
+```
+
+## Step 2: Stop 9Router
+
+```bash
+docker stop 9router
+```
+
+Keep the container (don't `docker rm`) — it serves as your rollback option.
+
+## Step 3: Prepare VansRouter data directory
+
+```bash
+# Create VansRouter data directory
+mkdir -p ~/.vansrouter/
+
+# Copy data from 9Router
+cp -r ~/.9router/db ~/.vansrouter/db
+cp ~/.9router/jwt-secret ~/.vansrouter/jwt-secret
+cp ~/.9router/machine-id ~/.vansrouter/machine-id
+cp -r ~/.9router/auth ~/.vansrouter/auth
+cp -r ~/.9router/mitm ~/.vansrouter/mitm 2>/dev/null || true
+cp -r ~/.9router/runtime ~/.vansrouter/runtime 2>/dev/null || true
+```
+
+## Step 4: Start VansRouter
+
+### Option A: Docker Compose (recommended)
+
+```bash
+# Copy environment template
+cp .env.example .env
+nano .env  # Set JWT_SECRET to match ~/.9router/jwt-secret
+
+# Start
+docker compose up -d
+```
+
+### Option B: Docker run
+
+```bash
+# Read your existing JWT secret
+JWT_SECRET=$(cat ~/.vansrouter/jwt-secret)
+
+docker run -d --name vansrouter --restart unless-stopped \
+  -p 20128:20128 \
+  -v ~/.vansrouter:/app/data \
+  -e PORT=20128 \
+  -e HOSTNAME=0.0.0.0 \
+  -e NODE_ENV=production \
+  -e DATA_DIR=/app/data \
+  -e JWT_SECRET="$JWT_SECRET" \
+  -e API_KEY_SECRET="$JWT_SECRET" \
+  -e REQUIRE_API_KEY=false \
+  ghcr.io/vanszs/vansrouter:latest
+```
+
+## Step 5: Verify
+
+```bash
+# Container running?
+docker ps --filter name=vansrouter
+
+# Dashboard accessible?
+curl -s -o /dev/null -w "%{http_code}" http://localhost:20128/
+# Expected: 200
+
+# Check migration logs
+docker logs vansrouter | grep -E "migrate|backup"
+# Expected: [DB][migrate] App 0.5.x → 0.8.6 | schema 1 → 3 | backup: ...
+
+# API responds?
+API_KEY=$(sqlite3 ~/.vansrouter/db/data.sqlite "SELECT key FROM apiKeys WHERE isActive=1;")
+curl -s -H "Authorization: Bearer $API_KEY" http://localhost:20128/v1/models | python3 -c "import sys,json; d=json.load(sys.stdin); print(f'Models: {len(d.get(\"data\",[]))}')"
+```
+
+Open the dashboard at `http://localhost:20128` and verify:
+- All combos appear with correct model lists
+- Provider connections show correct status
+- Usage history is intact
+
+## Step 6: Update dependent services
+
+If you use **Hermes Agent** or another client:
+
+- **Same port (20128)**: No config changes needed
+- **Different port**: Update `base_url` in your client config
+
+If you have auto-update crons for 9Router:
+
+```bash
+# Disable old 9Router update
+# (method depends on your setup: systemd timer, crontab, or Hermes cron)
+
+# Enable VansRouter auto-update script (example: nightly)
+# See scripts/vansrouter-docker-update.sh
+```
+
+## Rollback
+
+If anything goes wrong:
+
+```bash
+# Stop VansRouter
+docker stop vansrouter
+docker rm vansrouter
+
+# Restart 9Router
+docker start 9router
+```
+
+Your original data in `~/.9router/` is untouched. VansRouter data lives in `~/.vansrouter/`.
+
+## Schema changes during migration
+
+VansRouter applies these automatic migrations on first start:
+
+| Migration | What it does |
+|-----------|-------------|
+| 001-initial | Bootstrap tables (idempotent for existing DBs) |
+| 002-fix-empty-allowed-lists | Convert empty ACL arrays `[]` to NULL (unrestricted) |
+| 003-add-allowed-lists-columns | Add `allowedProviders`, `allowedCombos`, `allowedKinds` columns |
+
+A backup is automatically created at `~/.vansrouter/db/backups/` before migration runs.
+
+## Differences from 9Router
+
+- **Image**: `ghcr.io/vanszs/vansrouter` (not `decolua/9router`)
+- **Data dir**: `~/.vansrouter/` recommended (not `~/.9router/`)
+- **Headroom**: Optional sidecar for tool-history safety (not bundled)
+- **Circuit breaker**: Built-in provider failure tracking (inspired by OmniRoute)
+- **Active development**: Regular updates from upstream 9Router + community

--- a/src/app/(dashboard)/dashboard/providers/components/CircuitBreakerBadge.js
+++ b/src/app/(dashboard)/dashboard/providers/components/CircuitBreakerBadge.js
@@ -1,0 +1,32 @@
+/**
+ * CircuitBreakerBadge — compact badge showing circuit breaker state for a provider.
+ * Integrates into existing provider cards without requiring a new page.
+ */
+export default function CircuitBreakerBadge({ status, onReset }) {
+  if (!status || status.state === "CLOSED") return null;
+
+  const stateConfig = {
+    DEGRADED: { color: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400", icon: "warning", label: "Degraded" },
+    OPEN: { color: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400", icon: "power", label: "Circuit Open" },
+    HALF_OPEN: { color: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400", icon: "autorenew", label: "Recovering" },
+  };
+
+  const config = stateConfig[status.state] || stateConfig.DEGRADED;
+  const retryIn = status.retryAfterMs > 0 ? ` (${Math.ceil(status.retryAfterMs / 1000)}s)` : "";
+
+  return (
+    <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium ${config.color}`}>
+      <span className="material-symbols-outlined text-[12px]">{config.icon}</span>
+      {config.label}{retryIn}
+      {status.state === "OPEN" && onReset && (
+        <button
+          onClick={(e) => { e.preventDefault(); e.stopPropagation(); onReset(); }}
+          className="ml-0.5 hover:opacity-70 transition-opacity"
+          title="Reset circuit breaker"
+        >
+          <span className="material-symbols-outlined text-[12px]">refresh</span>
+        </button>
+      )}
+    </span>
+  );
+}

--- a/src/app/(dashboard)/dashboard/providers/page.js
+++ b/src/app/(dashboard)/dashboard/providers/page.js
@@ -24,6 +24,8 @@ import { useHeaderSearchStore } from "@/store/headerSearchStore";
 import { fetchCached } from "@/shared/utils/fetchCache";
 import ModelAvailabilityBadge from "./components/ModelAvailabilityBadge";
 import AddCompatibleModal from "./components/AddCompatibleModal";
+import { useCircuitBreakers } from "@/shared/hooks/useCircuitBreakers";
+import CircuitBreakerBadge from "./components/CircuitBreakerBadge";
 
 function getStatusDisplay(connected, error, errorCode) {
   const parts = [];
@@ -108,6 +110,7 @@ export default function ProvidersPage() {
   const searchQuery = useHeaderSearchStore((s) => s.query);
   const registerSearch = useHeaderSearchStore((s) => s.register);
   const unregisterSearch = useHeaderSearchStore((s) => s.unregister);
+  const { getCircuitBreakerForProvider, resetCircuitBreaker } = useCircuitBreakers();
 
   useEffect(() => {
     registerSearch("Search providers...");
@@ -383,6 +386,8 @@ export default function ProvidersPage() {
                   provider={info}
                   stats={getProviderStats(info.id, "apikey")}
                   authType="compatible"
+                  circuitBreaker={getCircuitBreakerForProvider(info.id)}
+                  onResetCircuit={resetCircuitBreaker}
                   onToggle={(active) =>
                     handleToggleProvider(info.id, "apikey", active)
                   }
@@ -430,6 +435,8 @@ export default function ProvidersPage() {
               provider={info}
               stats={getProviderStats(key, "oauth")}
               authType="oauth"
+              circuitBreaker={getCircuitBreakerForProvider(key)}
+              onResetCircuit={resetCircuitBreaker}
               onToggle={(active) => handleToggleProvider(key, "oauth", active)}
             />
           ))}
@@ -478,6 +485,8 @@ export default function ProvidersPage() {
                 provider={info}
                 stats={getProviderStats(key, freeAuthTypes)}
                 authType="free"
+                circuitBreaker={getCircuitBreakerForProvider(key)}
+                onResetCircuit={resetCircuitBreaker}
                 onToggle={(active) =>
                   handleToggleProvider(key, freeAuthTypes, active)
                 }
@@ -619,7 +628,7 @@ export default function ProvidersPage() {
   );
 }
 
-function ProviderCard({ providerId, provider, stats, authType, onToggle }) {
+function ProviderCard({ providerId, provider, stats, authType, onToggle, circuitBreaker, onResetCircuit }) {
   const { connected, error, errorCode, errorTime, allDisabled } = stats;
   const isNoAuth = !!provider.noAuth;
 
@@ -673,11 +682,17 @@ function ProviderCard({ providerId, provider, stats, authType, onToggle }) {
                       Disabled
                     </span>
                   </Badge>
-                ) : isNoAuth ? (
-                  <Badge variant="success" size="sm" dot>Ready</Badge>
                 ) : (
                   <>
                     {getStatusDisplay(connected, error, errorCode)}
+                    {circuitBreaker && (
+                      <CircuitBreakerBadge status={circuitBreaker} onReset={() => onResetCircuit(providerId)} />
+                    )}
+                    {errorTime && (
+                      <span className="text-text-muted">{errorTime}</span>
+                    )}
+                  </>
+                )}
                     {errorTime && (
                       <span className="text-text-muted">{errorTime}</span>
                     )}
@@ -719,6 +734,8 @@ function ApiKeyProviderCard({
   stats,
   authType,
   onToggle,
+  circuitBreaker,
+  onResetCircuit,
 }) {
   const { connected, error, errorCode, errorTime, allDisabled } = stats;
   const isCompatible = providerId.startsWith(OPENAI_COMPATIBLE_PREFIX);

--- a/src/app/api/providers/circuit-breakers/[name]/reset/route.js
+++ b/src/app/api/providers/circuit-breakers/[name]/reset/route.js
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { resetCircuitBreaker } from "@/open-sse/utils/circuitBreaker";
+
+export const runtime = "nodejs";
+
+/**
+ * POST /api/providers/circuit-breakers/[name]/reset
+ * Resets a specific circuit breaker to CLOSED state
+ */
+export async function POST(request, { params }) {
+  try {
+    const { name } = await params;
+    if (!name) {
+      return NextResponse.json(
+        { error: "Circuit breaker name is required" },
+        { status: 400 }
+      );
+    }
+
+    resetCircuitBreaker(decodeURIComponent(name));
+    return NextResponse.json({ success: true, message: `Circuit breaker "${name}" reset to CLOSED` });
+  } catch (error) {
+    console.error("Failed to reset circuit breaker:", error);
+    return NextResponse.json(
+      { error: "Failed to reset circuit breaker" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/providers/circuit-breakers/route.js
+++ b/src/app/api/providers/circuit-breakers/route.js
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { getAllCircuitBreakerStatuses } from "@/open-sse/utils/circuitBreaker";
+
+export const runtime = "nodejs";
+
+/**
+ * GET /api/providers/circuit-breakers
+ * Returns all active circuit breaker statuses
+ */
+export async function GET() {
+  try {
+    const statuses = getAllCircuitBreakerStatuses();
+    return NextResponse.json({ statuses });
+  } catch (error) {
+    console.error("Failed to fetch circuit breaker statuses:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch circuit breaker statuses" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/shared/hooks/useCircuitBreakers.js
+++ b/src/shared/hooks/useCircuitBreakers.js
@@ -1,0 +1,52 @@
+import { useState, useEffect } from "react";
+
+/**
+ * Hook to fetch and manage circuit breaker statuses
+ */
+export function useCircuitBreakers() {
+  const [statuses, setStatuses] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchStatuses = async () => {
+    try {
+      const res = await fetch("/api/providers/circuit-breakers");
+      const data = await res.json();
+      setStatuses(data.statuses || []);
+    } catch (error) {
+      console.error("Failed to fetch circuit breakers:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchStatuses();
+    const interval = setInterval(fetchStatuses, 5000); // Poll every 5s
+    return () => clearInterval(interval);
+  }, []);
+
+  const getCircuitBreakerForProvider = (providerId) => {
+    return statuses.find(s => s.name === providerId);
+  };
+
+  const resetCircuitBreaker = async (name) => {
+    try {
+      await fetch(`/api/providers/circuit-breakers/${encodeURIComponent(name)}/reset`, {
+        method: "POST"
+      });
+      await fetchStatuses();
+      return true;
+    } catch (error) {
+      console.error("Failed to reset circuit breaker:", error);
+      return false;
+    }
+  };
+
+  return {
+    statuses,
+    loading,
+    getCircuitBreakerForProvider,
+    resetCircuitBreaker,
+    refresh: fetchStatuses
+  };
+}


### PR DESCRIPTION
## Summary

Integrate circuit breaker status indicators into the existing Providers page without requiring a new dashboard section.

## Changes

### New Components
- `CircuitBreakerBadge` — compact badge showing circuit state (OPEN/DEGRADED/HALF_OPEN) with:
  - Color-coded states (red/amber/blue)
  - Retry countdown for OPEN state (e.g., "23s")
  - Manual reset button for OPEN circuits
  - Hidden when state is CLOSED (normal operation)

### API Endpoints
- `GET /api/providers/circuit-breakers` — fetch all active circuit breaker statuses
- `POST /api/providers/circuit-breakers/[name]/reset` — manually reset a circuit breaker to CLOSED

### Integration
- `useCircuitBreakers` hook polls every 5 seconds
- Badge appears next to existing connection status badges in provider cards
- Works with both `ProviderCard` (OAuth/Free) and `ApiKeyProviderCard` (API Key providers)
- Reset button triggers manual reset and refreshes status

## UI Behavior

**CLOSED** (normal): Badge hidden  
**DEGRADED**: ⚠️ Degraded (amber)  
**OPEN**: 🔴 Circuit Open (23s) with 🔄 reset button  
**HALF_OPEN**: 🔄 Recovering (blue)

## Testing

Tested with VansRouter v0.8.6 migration. Circuit breakers activate on repeated 5xx errors from providers and auto-recover after cooldown period.

## Screenshots

Badge appears inline with existing status indicators:
```
Gemini
● 3 Connected  ⚠️ Degraded  2m ago
```

When circuit trips:
```
OpenAI Compatible
● 2 Connected  🔴 Circuit Open (15s) 🔄  3m ago
```