### PR TITLE
fix(resilience): fix data race in semaphore acquire

### DIFF
--- a/internal/resilience/semaphore.go
+++ b/internal/resilience/semaphore.go
@@ -90,12 +90,13 @@ func (s *Semaphore) acquire(ctx context.Context, key string, maxConcurrency int,
 	if g == nil {
 		g = &gate{maxConcurrency: maxConcurrency}
 		s.gates[key] = g
-	} else {
-		g.maxConcurrency = maxConcurrency
 	}
 	s.mu.Unlock()
 
 	g.mu.Lock()
+	// Update maxConcurrency under g.mu to avoid data race:
+	// the value is read below while holding only g.mu.
+	g.maxConcurrency = maxConcurrency
 	if g.running < g.maxConcurrency && (g.blockedUntil.IsZero() || time.Now().After(g.blockedUntil)) {
 		g.running++
 		g.mu.Unlock()


### PR DESCRIPTION
## Problem

Data race in :  is written under  (map-level lock) but read under  (gate-level lock). Between  and , concurrent goroutines cause a data race.

**Reproduction:**
```bash
go test -race -run TestAccountSemaphore ./internal/resilience/
# WARNING: DATA RACE
# Write at semaphore.go:94 by goroutine 15
# Previous read at semaphore.go:99 by goroutine 14
```

## Fix

Move  inside the  critical section, after acquiring the gate lock. This ensures the field is only accessed while holding the correct mutex.

**Verification:**
```bash
go test -race ./...
# All 27 packages pass with race detector enabled
```