### PR TITLE
feat(db): Node.js database migration compatibility

### DIFF
--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -60,8 +60,26 @@ func loadMigrations() ([]migrationRecord, error) {
 	return records, nil
 }
 
+// detectNodejsVersion checks if the database was created by the Node.js backend
+// (9Router/VansRouter) by looking for the _meta table with a schemaVersion row.
+// Returns the version (1-based) if detected, 0 otherwise.
+// The Node.js backend uses _meta.key='schemaVersion' to track schema version.
+func detectNodejsVersion(database *sql.DB) int {
+	var version int
+	err := database.QueryRow(`SELECT CAST(value AS INTEGER) FROM _meta WHERE key = 'schemaVersion'`).Scan(&version)
+	if err != nil {
+		return 0
+	}
+	if version > 0 {
+		return version
+	}
+	return 0
+}
+
 // Migrate runs all embedded migrations that have not yet been applied.
 // It uses a schema_migrations table to track applied versions.
+// If the database was created by the Node.js backend (detected via _meta table),
+// all migrations up to the Node.js schemaVersion are pre-marked as applied.
 func Migrate(db *sql.DB) error {
 	records, err := loadMigrations()
 	if err != nil {
@@ -75,6 +93,16 @@ func Migrate(db *sql.DB) error {
 		)
 	`); err != nil {
 		return fmt.Errorf("create schema_migrations: %w", err)
+	}
+
+	// Detect Node.js backend and pre-seed schema_migrations
+	nodejsVer := detectNodejsVersion(db)
+	if nodejsVer > 0 {
+		for _, rec := range records {
+			if rec.Version <= nodejsVer {
+				db.Exec(`INSERT OR IGNORE INTO schema_migrations (version) VALUES (?)`, rec.Version)
+			}
+		}
 	}
 
 	for _, rec := range records {

--- a/internal/db/nodejs_compat_test.go
+++ b/internal/db/nodejs_compat_test.go
@@ -1,0 +1,91 @@
+package db
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+func TestMigrate_NodejsDB(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Simulate a Node.js 9Router DB with _meta table
+	_, err = db.Exec(`
+		CREATE TABLE _meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+		INSERT INTO _meta (key, value) VALUES ('schemaVersion', '3');
+		INSERT INTO _meta (key, value) VALUES ('appVersion', '0.8.6');
+		
+		CREATE TABLE apiKeys (
+			id TEXT PRIMARY KEY,
+			key TEXT UNIQUE NOT NULL,
+			name TEXT,
+			machineId TEXT,
+			isActive INTEGER DEFAULT 1,
+			createdAt TEXT NOT NULL,
+			allowedProviders TEXT,
+			allowedCombos TEXT,
+			allowedKinds TEXT
+		);
+		
+		CREATE TABLE combos (
+			id TEXT PRIMARY KEY,
+			name TEXT UNIQUE NOT NULL,
+			kind TEXT,
+			models TEXT NOT NULL,
+			createdAt TEXT NOT NULL,
+			updatedAt TEXT NOT NULL
+		);
+		
+		INSERT INTO apiKeys VALUES ('test-key', 'sk-test', 'test', 'machine1', 1, '2024-01-01', NULL, NULL, NULL);
+		INSERT INTO combos VALUES ('combo1', 'default', 'llm', '["gpt-4"]', '2024-01-01', '2024-01-01');
+	`)
+	require.NoError(t, err)
+
+	// Run migration
+	err = Migrate(db)
+	require.NoError(t, err, "Migrate should succeed on Node.js DB")
+
+	// Verify schema_migrations was populated
+	var count int
+	err = db.QueryRow("SELECT COUNT(*) FROM schema_migrations").Scan(&count)
+	require.NoError(t, err)
+	assert.Greater(t, count, 0, "schema_migrations should have entries")
+
+	// Verify existing data preserved
+	var keyCount int
+	err = db.QueryRow("SELECT COUNT(*) FROM apiKeys").Scan(&keyCount)
+	require.NoError(t, err)
+	assert.Equal(t, 1, keyCount, "apiKeys data should be preserved")
+
+	var comboCount int
+	err = db.QueryRow("SELECT COUNT(*) FROM combos").Scan(&comboCount)
+	require.NoError(t, err)
+	assert.Equal(t, 1, comboCount, "combos data should be preserved")
+}
+
+func TestDetectNodejsVersion(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Test 1: No _meta table
+	ver := detectNodejsVersion(db)
+	assert.Equal(t, 0, ver, "should return 0 when no _meta table")
+
+	// Test 2: _meta table exists but no schemaVersion
+	_, err = db.Exec("CREATE TABLE _meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+	require.NoError(t, err)
+	ver = detectNodejsVersion(db)
+	assert.Equal(t, 0, ver, "should return 0 when no schemaVersion")
+
+	// Test 3: schemaVersion exists
+	_, err = db.Exec("INSERT INTO _meta (key, value) VALUES ('schemaVersion', '3')")
+	require.NoError(t, err)
+	ver = detectNodejsVersion(db)
+	assert.Equal(t, 3, ver, "should return 3 when schemaVersion=3")
+}


### PR DESCRIPTION
## Summary

Enables Go port to seamlessly migrate from Node.js 9Router/VansRouter databases without data loss or duplicate migration errors.

## Changes

- **Detection**: Check for `_meta.schemaVersion` table (Node.js migration tracking)
- **Pre-seed**: Populate Go's `schema_migrations` table for already-applied migrations
- **Data preservation**: Existing tables (apiKeys, combos, usageHistory, etc.) remain intact
- **Tests**: Comprehensive coverage for detection logic and migration scenarios

## Testing

```bash
go test ./internal/db/ -v
# All 4 tests pass:
# - TestMigrate (fresh DB)
# - TestOpenCreatesDataDir
# - TestMigrate_NodejsDB (Node.js DB with schemaVersion=3)
# - TestDetectNodejsVersion
```

## Migration Path

**Before (broken):**
```bash
# Copy Node.js DB
cp ~/.vansrouter/db/data.sqlite /tmp/test.db
# Go port fails: table already exists errors
```

**After (works):**
```bash
# Copy Node.js DB
cp ~/.vansrouter/db/data.sqlite /tmp/test.db
# Go port detects schemaVersion=3, skips migrations 1-3
# Data preserved, new migrations (4+) apply cleanly
```

## Technical Details

Node.js tracks migrations in `_meta` table:
```sql
_meta: schemaVersion=3, appVersion=0.8.6
```

Go port tracks in `schema_migrations`:
```sql
schema_migrations: version INTEGER, applied_at TEXT
```

This fix bridges both systems by detecting Node.js version and pre-populating Go's tracking table.