### PR TITLE
feat(dashboard): serve real model list from ModelsList stub

### DIFF
--- a/internal/api/dashboard/stubs.go
+++ b/internal/api/dashboard/stubs.go
@@ -3,16 +3,23 @@ package dashboard
 import (
 	"encoding/json"
 	"net/http"
+
+	"github.com/9router/9router/internal/models"
 )
 
 // StubsHandlers holds placeholder implementations for dashboard routes that
 // are not fully ported to Go yet. They return empty but shape-valid responses
 // so the frontend never hits a 404/500 while navigating the dashboard.
-type StubsHandlers struct{}
+type StubsHandlers struct {
+	// Builder is the model list builder, used by ModelsList to serve the
+	// /api/models route with real data instead of an empty stub.
+	Builder *models.Builder
+}
 
-// NewStubsHandlers creates stub handlers.
-func NewStubsHandlers() *StubsHandlers {
-	return &StubsHandlers{}
+// NewStubsHandlers creates stub handlers. The builder parameter is optional;
+// pass nil to keep the old empty-stub behaviour for routes that don't need it.
+func NewStubsHandlers(builder *models.Builder) *StubsHandlers {
+	return &StubsHandlers{Builder: builder}
 }
 
 func (h *StubsHandlers) empty(w http.ResponseWriter, r *http.Request) {
@@ -82,8 +89,19 @@ func (h *StubsHandlers) OIDCTest(w http.ResponseWriter, r *http.Request) {
 // Model stubs
 
 // ModelsList handles GET /api/models.
+// If the handler was created with a Builder, it serves the real model list;
+// otherwise it falls back to the empty-stub response.
 func (h *StubsHandlers) ModelsList(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, map[string]any{"models": []any{}})
+	if h.Builder == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"models": []any{}})
+		return
+	}
+	list, err := h.Builder.BuildModelsList(r.Context(), models.AllKinds)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to build models list")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"models": list})
 }
 
 // ModelAliases handles GET /api/models/alias.

--- a/internal/api/dashboard/stubs_test.go
+++ b/internal/api/dashboard/stubs_test.go
@@ -1,0 +1,58 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/9router/9router/internal/models"
+)
+
+// stubSource implements models.Source for testing.
+type stubSource struct {
+	snap *models.SourceSnapshot
+	err  error
+}
+
+func (s *stubSource) Snapshot(context.Context) (*models.SourceSnapshot, error) {
+	return s.snap, s.err
+}
+
+func TestModelsList_NilBuilder_ReturnsEmpty(t *testing.T) {
+	h := NewStubsHandlers(nil)
+	req := httptest.NewRequest("GET", "/api/models", nil)
+	rec := httptest.NewRecorder()
+	h.ModelsList(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	modelsList, ok := body["models"].([]any)
+	if !ok {
+		t.Fatal("expected 'models' array in response")
+	}
+	if len(modelsList) != 0 {
+		t.Fatalf("expected empty models array, got %d items", len(modelsList))
+	}
+}
+
+func TestModelsList_WithBuilder_ReturnsError(t *testing.T) {
+	// When the builder returns an error, ModelsList should respond with 500.
+	src := &stubSource{err: context.DeadlineExceeded}
+	builder := models.NewBuilder(nil, src)
+
+	h := NewStubsHandlers(builder)
+	req := httptest.NewRequest("GET", "/api/models", nil)
+	rec := httptest.NewRecorder()
+	h.ModelsList(rec, req)
+
+	if rec.Code != 500 {
+		t.Fatalf("expected 500 on builder error, got %d", rec.Code)
+	}
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -90,7 +90,7 @@ func dashboardRouter(r *repos.Repos, registry *providers.Registry, builder *mode
 	router.With(dashboard.RequireSession).Get("/usage/{connectionId}", usageHandlers.ConnectionUsage)
 	router.With(dashboard.RequireSession).Post("/usage/{connectionId}/codex-reset-credits", usageHandlers.CodexResetCredits)
 
-	stubs := dashboard.NewStubsHandlers()
+	stubs := dashboard.NewStubsHandlers(builder)
 
 	router.With(dashboard.RequireSession).Post("/providers/{id}/test", stubs.ProviderTest)
 
@@ -294,7 +294,7 @@ func v1Router(r *repos.Repos, builder *models.Builder) http.Handler {
 	messagesHandler := &v1.MessagesHandler{}
 	router.Post("/messages/count_tokens", http.HandlerFunc(messagesHandler.ServeHTTP))
 
-	stubs := dashboard.NewStubsHandlers()
+	stubs := dashboard.NewStubsHandlers(builder)
 	router.Post("/audio/transcriptions", stubs.V1AudioTranscriptions)
 	router.Post("/embeddings", stubs.V1Embeddings)
 


### PR DESCRIPTION
## Summary

The `ModelsList` dashboard handler (`GET /api/models`) was returning an empty array even though the `models.Builder` was already constructed and available in the router setup. This wires the builder into `StubsHandlers` so the dashboard serves real model data.

## Changes

- `StubsHandlers` now accepts an optional `*models.Builder` parameter
- `ModelsList` calls `builder.BuildModelsList()` when builder is non-nil
- Falls back to empty array when builder is nil (backward compatible)
- Routes updated to pass `builder` to `NewStubsHandlers` in both call sites
- Tests cover nil-builder (empty response) and error paths (500 response)

## Testing

```shell
go test -race -v -run TestModelsList ./internal/api/dashboard/
# === RUN   TestModelsList_NilBuilder_ReturnsEmpty
# --- PASS
# === RUN   TestModelsList_WithBuilder_ReturnsError
# --- PASS
# PASS

go test -race ./...
# All 27 packages pass
```

## Impact

Dashboard Models page currently shows zero models on Go port. After this PR, it will show the full model list (same as `/v1/models` endpoint already serves).
