### PR TITLE
feat(executors): port 11 missing provider executors

### DIFF
--- a/internal/providers/executors/antigravity.go
+++ b/internal/providers/executors/antigravity.go
@@ -1,0 +1,53 @@
+package executors
+
+import (
+	"net/http"
+	"strings"
+)
+
+// AntigravityExecutor targets Antigravity's Gemini-compatible API.
+type AntigravityExecutor struct {
+	BaseExecutor
+}
+
+// NewAntigravityExecutor creates an Antigravity executor.
+func NewAntigravityExecutor(provider string, cfg *ProviderConfig) *AntigravityExecutor {
+	return &AntigravityExecutor{BaseExecutor: *NewBaseExecutor(provider, cfg)}
+}
+
+// BuildURL returns the Antigravity endpoint.
+func (ex *AntigravityExecutor) BuildURL(model string, stream bool, urlIndex int, creds Credentials) string {
+	if url := ex.BaseExecutor.BuildURL(model, stream, urlIndex, creds); url != "" {
+		return url
+	}
+
+	// Antigravity uses Gemini-compatible endpoints
+	baseURL := "https://api.antigravity.ai"
+	if b, _ := creds.ProviderSpecificData["baseUrl"].(string); b != "" {
+		baseURL = strings.TrimSuffix(b, "/")
+	}
+
+	action := "generateContent"
+	if stream {
+		action = "streamGenerateContent?alt=sse"
+	}
+	return baseURL + "/" + model + ":" + action
+}
+
+// BuildHeaders sets Antigravity auth headers.
+func (ex *AntigravityExecutor) BuildHeaders(creds Credentials, stream bool) http.Header {
+	h := ex.BaseExecutor.BuildHeaders(creds, stream)
+
+	// Antigravity uses Bearer auth
+	if creds.APIKey != "" {
+		h.Set("Authorization", "Bearer "+creds.APIKey)
+	}
+
+	return h
+}
+
+func init() {
+	Register("antigravity", func(provider string, cfg *ProviderConfig) Executor {
+		return NewAntigravityExecutor(provider, cfg)
+	})
+}

--- a/internal/providers/executors/codebuddy_cn.go
+++ b/internal/providers/executors/codebuddy_cn.go
@@ -1,0 +1,46 @@
+package executors
+
+import (
+	"net/http"
+	"strings"
+)
+
+// CodebuddyCnExecutor targets Codebuddy CN API.
+type CodebuddyCnExecutor struct {
+	DefaultExecutor
+}
+
+// NewCodebuddyCnExecutor creates a Codebuddy CN executor.
+func NewCodebuddyCnExecutor(provider string, cfg *ProviderConfig) *CodebuddyCnExecutor {
+	return &CodebuddyCnExecutor{DefaultExecutor: *NewDefaultExecutor(provider, cfg)}
+}
+
+// BuildURL returns the Codebuddy CN endpoint.
+func (ex *CodebuddyCnExecutor) BuildURL(model string, stream bool, urlIndex int, creds Credentials) string {
+	if url := ex.BaseExecutor.BuildURL(model, stream, urlIndex, creds); url != "" {
+		return url
+	}
+
+	baseURL := "https://api.codebuddy.cn"
+	if b, _ := creds.ProviderSpecificData["baseUrl"].(string); b != "" {
+		baseURL = strings.TrimSuffix(b, "/")
+	}
+	return baseURL + "/v1/chat/completions"
+}
+
+// BuildHeaders sets Codebuddy CN auth headers.
+func (ex *CodebuddyCnExecutor) BuildHeaders(creds Credentials, stream bool) http.Header {
+	h := ex.DefaultExecutor.BuildHeaders(creds, stream)
+
+	if creds.APIKey != "" {
+		h.Set("Authorization", "Bearer "+creds.APIKey)
+	}
+
+	return h
+}
+
+func init() {
+	Register("codebuddy-cn", func(provider string, cfg *ProviderConfig) Executor {
+		return NewCodebuddyCnExecutor(provider, cfg)
+	})
+}

--- a/internal/providers/executors/commandcode.go
+++ b/internal/providers/executors/commandcode.go
@@ -1,0 +1,46 @@
+package executors
+
+import (
+	"net/http"
+	"strings"
+)
+
+// CommandCodeExecutor targets CommandCode API.
+type CommandCodeExecutor struct {
+	DefaultExecutor
+}
+
+// NewCommandCodeExecutor creates a CommandCode executor.
+func NewCommandCodeExecutor(provider string, cfg *ProviderConfig) *CommandCodeExecutor {
+	return &CommandCodeExecutor{DefaultExecutor: *NewDefaultExecutor(provider, cfg)}
+}
+
+// BuildURL returns the CommandCode endpoint.
+func (ex *CommandCodeExecutor) BuildURL(model string, stream bool, urlIndex int, creds Credentials) string {
+	if url := ex.BaseExecutor.BuildURL(model, stream, urlIndex, creds); url != "" {
+		return url
+	}
+
+	baseURL := "https://api.commandcode.dev"
+	if b, _ := creds.ProviderSpecificData["baseUrl"].(string); b != "" {
+		baseURL = strings.TrimSuffix(b, "/")
+	}
+	return baseURL + "/alpha/generate"
+}
+
+// BuildHeaders sets CommandCode auth headers.
+func (ex *CommandCodeExecutor) BuildHeaders(creds Credentials, stream bool) http.Header {
+	h := ex.DefaultExecutor.BuildHeaders(creds, stream)
+
+	if creds.APIKey != "" {
+		h.Set("Authorization", "Bearer "+creds.APIKey)
+	}
+
+	return h
+}
+
+func init() {
+	Register("commandcode", func(provider string, cfg *ProviderConfig) Executor {
+		return NewCommandCodeExecutor(provider, cfg)
+	})
+}

--- a/internal/providers/executors/gemini_cli.go
+++ b/internal/providers/executors/gemini_cli.go
@@ -1,0 +1,55 @@
+package executors
+
+import (
+	"net/http"
+	"os"
+	"strings"
+)
+
+// GeminiCliExecutor targets Gemini CLI API.
+type GeminiCliExecutor struct {
+	BaseExecutor
+}
+
+// NewGeminiCliExecutor creates a Gemini CLI executor.
+func NewGeminiCliExecutor(provider string, cfg *ProviderConfig) *GeminiCliExecutor {
+	return &GeminiCliExecutor{BaseExecutor: *NewBaseExecutor(provider, cfg)}
+}
+
+// BuildURL returns the Gemini CLI endpoint.
+func (ex *GeminiCliExecutor) BuildURL(model string, stream bool, urlIndex int, creds Credentials) string {
+	if url := ex.BaseExecutor.BuildURL(model, stream, urlIndex, creds); url != "" {
+		return url
+	}
+
+	baseURL := "https://generativelanguage.googleapis.com"
+	if b, _ := creds.ProviderSpecificData["baseUrl"].(string); b != "" {
+		baseURL = strings.TrimSuffix(b, "/")
+	} else if b := os.Getenv("GOOGLE_GEMINI_BASE_URL"); b != "" {
+		baseURL = strings.TrimSuffix(b, "/")
+	}
+
+	action := "generateContent"
+	if stream {
+		action = "streamGenerateContent?alt=sse"
+	}
+	return baseURL + "/v1beta/models/" + model + ":" + action
+}
+
+// BuildHeaders sets Gemini CLI auth headers.
+func (ex *GeminiCliExecutor) BuildHeaders(creds Credentials, stream bool) http.Header {
+	h := ex.BaseExecutor.BuildHeaders(creds, stream)
+
+	// Gemini CLI uses x-goog-api-key header
+	if creds.APIKey != "" {
+		h.Set("x-goog-api-key", creds.APIKey)
+	}
+
+	return h
+}
+
+func init() {
+	Register("gemini-cli", func(provider string, cfg *ProviderConfig) Executor {
+		return NewGeminiCliExecutor(provider, cfg)
+	})
+}

--- a/internal/providers/executors/grok_web.go
+++ b/internal/providers/executors/grok_web.go
@@ -1,0 +1,46 @@
+package executors
+
+import (
+	"net/http"
+	"strings"
+)
+
+// GrokWebExecutor targets Grok web API.
+type GrokWebExecutor struct {
+	DefaultExecutor
+}
+
+// NewGrokWebExecutor creates a Grok web executor.
+func NewGrokWebExecutor(provider string, cfg *ProviderConfig) *GrokWebExecutor {
+	return &GrokWebExecutor{DefaultExecutor: *NewDefaultExecutor(provider, cfg)}
+}
+
+// BuildURL returns the Grok web endpoint.
+func (ex *GrokWebExecutor) BuildURL(model string, stream bool, urlIndex int, creds Credentials) string {
+	if url := ex.BaseExecutor.BuildURL(model, stream, urlIndex, creds); url != "" {
+		return url
+	}
+
+	baseURL := "https://api.x.ai"
+	if b, _ := creds.ProviderSpecificData["baseUrl"].(string); b != "" {
+		baseURL = strings.TrimSuffix(b, "/")
+	}
+	return baseURL + "/v1/chat/completions"
+}
+
+// BuildHeaders sets Grok web auth headers.
+func (ex *GrokWebExecutor) BuildHeaders(creds Credentials, stream bool) http.Header {
+	h := ex.DefaultExecutor.BuildHeaders(creds, stream)
+
+	if creds.APIKey != "" {
+		h.Set("Authorization", "Bearer "+creds.APIKey)
+	}
+
+	return h
+}
+
+func init() {
+	Register("grok-web", func(provider string, cfg *ProviderConfig) Executor {
+		return NewGrokWebExecutor(provider, cfg)
+	})
+}

--- a/internal/providers/executors/iflow.go
+++ b/internal/providers/executors/iflow.go
@@ -1,0 +1,46 @@
+package executors
+
+import (
+	"net/http"
+	"strings"
+)
+
+// IFlowExecutor targets IFlow API.
+type IFlowExecutor struct {
+	DefaultExecutor
+}
+
+// NewIFlowExecutor creates an IFlow executor.
+func NewIFlowExecutor(provider string, cfg *ProviderConfig) *IFlowExecutor {
+	return &IFlowExecutor{DefaultExecutor: *NewDefaultExecutor(provider, cfg)}
+}
+
+// BuildURL returns the IFlow endpoint.
+func (ex *IFlowExecutor) BuildURL(model string, stream bool, urlIndex int, creds Credentials) string {
+	if url := ex.BaseExecutor.BuildURL(model, stream, urlIndex, creds); url != "" {
+		return url
+	}
+
+	baseURL := "https://api.iflow.cn"
+	if b, _ := creds.ProviderSpecificData["baseUrl"].(string); b != "" {
+		baseURL = strings.TrimSuffix(b, "/")
+	}
+	return baseURL + "/v1/chat/completions"
+}
+
+// BuildHeaders sets IFlow auth headers.
+func (ex *IFlowExecutor) BuildHeaders(creds Credentials, stream bool) http.Header {
+	h := ex.DefaultExecutor.BuildHeaders(creds, stream)
+
+	if creds.APIKey != "" {
+		h.Set("Authorization", "Bearer "+creds.APIKey)
+	}
+
+	return h
+}
+
+func init() {
+	Register("iflow", func(provider string, cfg *ProviderConfig) Executor {
+		return NewIFlowExecutor(provider, cfg)
+	})
+}

--- a/internal/providers/executors/kiro.go
+++ b/internal/providers/executors/kiro.go
@@ -1,0 +1,46 @@
+package executors
+
+import (
+	"net/http"
+	"strings"
+)
+
+// KiroExecutor targets AWS Kiro (CodeWhisperer) API.
+type KiroExecutor struct {
+	DefaultExecutor
+}
+
+// NewKiroExecutor creates a Kiro executor.
+func NewKiroExecutor(provider string, cfg *ProviderConfig) *KiroExecutor {
+	return &KiroExecutor{DefaultExecutor: *NewDefaultExecutor(provider, cfg)}
+}
+
+// BuildURL returns the Kiro endpoint.
+func (ex *KiroExecutor) BuildURL(model string, stream bool, urlIndex int, creds Credentials) string {
+	if url := ex.BaseExecutor.BuildURL(model, stream, urlIndex, creds); url != "" {
+		return url
+	}
+
+	baseURL := "https://codewhisperer.us-east-1.amazonaws.com"
+	if b, _ := creds.ProviderSpecificData["baseUrl"].(string); b != "" {
+		baseURL = strings.TrimSuffix(b, "/")
+	}
+	return baseURL + "/" + model + "/completions"
+}
+
+// BuildHeaders sets Kiro auth headers.
+func (ex *KiroExecutor) BuildHeaders(creds Credentials, stream bool) http.Header {
+	h := ex.DefaultExecutor.BuildHeaders(creds, stream)
+
+	if creds.APIKey != "" {
+		h.Set("Authorization", "Bearer "+creds.APIKey)
+	}
+
+	return h
+}
+
+func init() {
+	Register("kiro", func(provider string, cfg *ProviderConfig) Executor {
+		return NewKiroExecutor(provider, cfg)
+	})
+}

--- a/internal/providers/executors/new_executors_test.go
+++ b/internal/providers/executors/new_executors_test.go
@@ -1,0 +1,159 @@
+package executors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSpecialExecutors_NewExecutors(t *testing.T) {
+	t.Run("Antigravity", func(t *testing.T) {
+		ex := NewAntigravityExecutor("antigravity", &ProviderConfig{})
+		assert.Equal(t, "antigravity", ex.Provider())
+
+		url := ex.BuildURL("gemini-pro", false, 0, Credentials{})
+		assert.Contains(t, url, "api.antigravity.ai")
+		assert.Contains(t, url, "gemini-pro")
+		assert.Contains(t, url, "generateContent")
+
+		urlStream := ex.BuildURL("gemini-pro", true, 0, Credentials{})
+		assert.Contains(t, urlStream, "streamGenerateContent")
+	})
+
+	t.Run("CodebuddyCn", func(t *testing.T) {
+		ex := NewCodebuddyCnExecutor("codebuddy-cn", &ProviderConfig{})
+		assert.Equal(t, "codebuddy-cn", ex.Provider())
+
+		url := ex.BuildURL("model", false, 0, Credentials{})
+		assert.Contains(t, url, "api.codebuddy.cn")
+		assert.Contains(t, url, "chat/completions")
+	})
+
+	t.Run("CommandCode", func(t *testing.T) {
+		ex := NewCommandCodeExecutor("commandcode", &ProviderConfig{})
+		assert.Equal(t, "commandcode", ex.Provider())
+
+		url := ex.BuildURL("model", false, 0, Credentials{})
+		assert.Contains(t, url, "api.commandcode.dev")
+		assert.Contains(t, url, "alpha/generate")
+	})
+
+	t.Run("GeminiCli", func(t *testing.T) {
+		ex := NewGeminiCliExecutor("gemini-cli", &ProviderConfig{})
+		assert.Equal(t, "gemini-cli", ex.Provider())
+
+		url := ex.BuildURL("gemini-pro", false, 0, Credentials{})
+		assert.Contains(t, url, "generativelanguage.googleapis.com")
+		assert.Contains(t, url, "gemini-pro")
+
+		h := ex.BuildHeaders(Credentials{APIKey: "test-key"}, true)
+		assert.Equal(t, "test-key", h.Get("x-goog-api-key"))
+	})
+
+	t.Run("GrokWeb", func(t *testing.T) {
+		ex := NewGrokWebExecutor("grok-web", &ProviderConfig{})
+		assert.Equal(t, "grok-web", ex.Provider())
+
+		url := ex.BuildURL("model", false, 0, Credentials{})
+		assert.Contains(t, url, "api.x.ai")
+	})
+
+	t.Run("IFlow", func(t *testing.T) {
+		ex := NewIFlowExecutor("iflow", &ProviderConfig{})
+		assert.Equal(t, "iflow", ex.Provider())
+
+		url := ex.BuildURL("model", false, 0, Credentials{})
+		assert.Contains(t, url, "api.iflow.cn")
+	})
+
+	t.Run("Kiro", func(t *testing.T) {
+		ex := NewKiroExecutor("kiro", &ProviderConfig{})
+		assert.Equal(t, "kiro", ex.Provider())
+
+		url := ex.BuildURL("model", false, 0, Credentials{})
+		assert.Contains(t, url, "codewhisperer.us-east-1.amazonaws.com")
+	})
+
+	t.Run("OpenCode", func(t *testing.T) {
+		ex := NewOpenCodeExecutor("opencode", &ProviderConfig{})
+		assert.Equal(t, "opencode", ex.Provider())
+
+		url := ex.BuildURL("model", false, 0, Credentials{})
+		assert.Contains(t, url, "api.opencode.ai")
+	})
+
+	t.Run("Qoder", func(t *testing.T) {
+		ex := NewQoderExecutor("qoder", &ProviderConfig{})
+		assert.Equal(t, "qoder", ex.Provider())
+
+		url := ex.BuildURL("model", false, 0, Credentials{})
+		assert.Contains(t, url, "api.qoder.ai")
+	})
+
+	t.Run("Qwen", func(t *testing.T) {
+		ex := NewQwenExecutor("qwen", &ProviderConfig{})
+		assert.Equal(t, "qwen", ex.Provider())
+
+		url := ex.BuildURL("model", false, 0, Credentials{})
+		assert.Contains(t, url, "dashscope.aliyuncs.com")
+	})
+
+	t.Run("XiaomiTokenplan", func(t *testing.T) {
+		ex := NewXiaomiTokenplanExecutor("xiaomi-tokenplan", &ProviderConfig{})
+		assert.Equal(t, "xiaomi-tokenplan", ex.Provider())
+
+		url := ex.BuildURL("model", false, 0, Credentials{})
+		assert.Contains(t, url, "api.mimo.xiaomi.com")
+	})
+}
+
+func TestSpecialExecutors_Registry_NewExecutors(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+	}{
+		{"Antigravity", "antigravity"},
+		{"CodebuddyCn", "codebuddy-cn"},
+		{"CommandCode", "commandcode"},
+		{"GeminiCli", "gemini-cli"},
+		{"GrokWeb", "grok-web"},
+		{"IFlow", "iflow"},
+		{"Kiro", "kiro"},
+		{"OpenCode", "opencode"},
+		{"Qoder", "qoder"},
+		{"Qwen", "qwen"},
+		{"XiaomiTokenplan", "xiaomi-tokenplan"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ex := Get(tt.provider, &ProviderConfig{})
+			assert.NotNil(t, ex)
+			// Type assert to check provider name
+			switch v := ex.(type) {
+			case *AntigravityExecutor:
+				assert.Equal(t, tt.provider, v.Provider())
+			case *CodebuddyCnExecutor:
+				assert.Equal(t, tt.provider, v.Provider())
+			case *CommandCodeExecutor:
+				assert.Equal(t, tt.provider, v.Provider())
+			case *GeminiCliExecutor:
+				assert.Equal(t, tt.provider, v.Provider())
+			case *GrokWebExecutor:
+				assert.Equal(t, tt.provider, v.Provider())
+			case *IFlowExecutor:
+				assert.Equal(t, tt.provider, v.Provider())
+			case *KiroExecutor:
+				assert.Equal(t, tt.provider, v.Provider())
+			case *OpenCodeExecutor:
+				assert.Equal(t, tt.provider, v.Provider())
+			case *QoderExecutor:
+				assert.Equal(t, tt.provider, v.Provider())
+			case *QwenExecutor:
+				assert.Equal(t, tt.provider, v.Provider())
+			case *XiaomiTokenplanExecutor:
+				assert.Equal(t, tt.provider, v.Provider())
+			}
+		})
+	}
+}

--- a/internal/providers/executors/opencode.go
+++ b/internal/providers/executors/opencode.go
@@ -1,0 +1,46 @@
+package executors
+
+import (
+	"net/http"
+	"strings"
+)
+
+// OpenCodeExecutor targets OpenCode API.
+type OpenCodeExecutor struct {
+	DefaultExecutor
+}
+
+// NewOpenCodeExecutor creates an OpenCode executor.
+func NewOpenCodeExecutor(provider string, cfg *ProviderConfig) *OpenCodeExecutor {
+	return &OpenCodeExecutor{DefaultExecutor: *NewDefaultExecutor(provider, cfg)}
+}
+
+// BuildURL returns the OpenCode endpoint.
+func (ex *OpenCodeExecutor) BuildURL(model string, stream bool, urlIndex int, creds Credentials) string {
+	if url := ex.BaseExecutor.BuildURL(model, stream, urlIndex, creds); url != "" {
+		return url
+	}
+
+	baseURL := "https://api.opencode.ai"
+	if b, _ := creds.ProviderSpecificData["baseUrl"].(string); b != "" {
+		baseURL = strings.TrimSuffix(b, "/")
+	}
+	return baseURL + "/v1/chat/completions"
+}
+
+// BuildHeaders sets OpenCode auth headers.
+func (ex *OpenCodeExecutor) BuildHeaders(creds Credentials, stream bool) http.Header {
+	h := ex.DefaultExecutor.BuildHeaders(creds, stream)
+
+	if creds.APIKey != "" {
+		h.Set("Authorization", "Bearer "+creds.APIKey)
+	}
+
+	return h
+}
+
+func init() {
+	Register("opencode", func(provider string, cfg *ProviderConfig) Executor {
+		return NewOpenCodeExecutor(provider, cfg)
+	})
+}

--- a/internal/providers/executors/qoder.go
+++ b/internal/providers/executors/qoder.go
@@ -1,0 +1,46 @@
+package executors
+
+import (
+	"net/http"
+	"strings"
+)
+
+// QoderExecutor targets Qoder API.
+type QoderExecutor struct {
+	DefaultExecutor
+}
+
+// NewQoderExecutor creates a Qoder executor.
+func NewQoderExecutor(provider string, cfg *ProviderConfig) *QoderExecutor {
+	return &QoderExecutor{DefaultExecutor: *NewDefaultExecutor(provider, cfg)}
+}
+
+// BuildURL returns the Qoder endpoint.
+func (ex *QoderExecutor) BuildURL(model string, stream bool, urlIndex int, creds Credentials) string {
+	if url := ex.BaseExecutor.BuildURL(model, stream, urlIndex, creds); url != "" {
+		return url
+	}
+
+	baseURL := "https://api.qoder.ai"
+	if b, _ := creds.ProviderSpecificData["baseUrl"].(string); b != "" {
+		baseURL = strings.TrimSuffix(b, "/")
+	}
+	return baseURL + "/v1/chat/completions"
+}
+
+// BuildHeaders sets Qoder auth headers.
+func (ex *QoderExecutor) BuildHeaders(creds Credentials, stream bool) http.Header {
+	h := ex.DefaultExecutor.BuildHeaders(creds, stream)
+
+	if creds.APIKey != "" {
+		h.Set("Authorization", "Bearer "+creds.APIKey)
+	}
+
+	return h
+}
+
+func init() {
+	Register("qoder", func(provider string, cfg *ProviderConfig) Executor {
+		return NewQoderExecutor(provider, cfg)
+	})
+}

--- a/internal/providers/executors/qwen.go
+++ b/internal/providers/executors/qwen.go
@@ -1,0 +1,46 @@
+package executors
+
+import (
+	"net/http"
+	"strings"
+)
+
+// QwenExecutor targets Qwen (Alibaba) API.
+type QwenExecutor struct {
+	DefaultExecutor
+}
+
+// NewQwenExecutor creates a Qwen executor.
+func NewQwenExecutor(provider string, cfg *ProviderConfig) *QwenExecutor {
+	return &QwenExecutor{DefaultExecutor: *NewDefaultExecutor(provider, cfg)}
+}
+
+// BuildURL returns the Qwen endpoint.
+func (ex *QwenExecutor) BuildURL(model string, stream bool, urlIndex int, creds Credentials) string {
+	if url := ex.BaseExecutor.BuildURL(model, stream, urlIndex, creds); url != "" {
+		return url
+	}
+
+	baseURL := "https://dashscope.aliyuncs.com/compatible-mode"
+	if b, _ := creds.ProviderSpecificData["baseUrl"].(string); b != "" {
+		baseURL = strings.TrimSuffix(b, "/")
+	}
+	return baseURL + "/v1/chat/completions"
+}
+
+// BuildHeaders sets Qwen auth headers.
+func (ex *QwenExecutor) BuildHeaders(creds Credentials, stream bool) http.Header {
+	h := ex.DefaultExecutor.BuildHeaders(creds, stream)
+
+	if creds.APIKey != "" {
+		h.Set("Authorization", "Bearer "+creds.APIKey)
+	}
+
+	return h
+}
+
+func init() {
+	Register("qwen", func(provider string, cfg *ProviderConfig) Executor {
+		return NewQwenExecutor(provider, cfg)
+	})
+}

--- a/internal/providers/executors/xiaomi_tokenplan.go
+++ b/internal/providers/executors/xiaomi_tokenplan.go
@@ -1,0 +1,54 @@
+package executors
+
+import (
+	"net/http"
+	"strings"
+)
+
+// XiaomiTokenplanExecutor targets Xiaomi Tokenplan API.
+type XiaomiTokenplanExecutor struct {
+	DefaultExecutor
+}
+
+// NewXiaomiTokenplanExecutor creates a Xiaomi Tokenplan executor.
+func NewXiaomiTokenplanExecutor(provider string, cfg *ProviderConfig) *XiaomiTokenplanExecutor {
+	return &XiaomiTokenplanExecutor{DefaultExecutor: *NewDefaultExecutor(provider, cfg)}
+}
+
+// BuildURL returns the Xiaomi Tokenplan endpoint.
+func (ex *XiaomiTokenplanExecutor) BuildURL(model string, stream bool, urlIndex int, creds Credentials) string {
+	if url := ex.BaseExecutor.BuildURL(model, stream, urlIndex, creds); url != "" {
+		return url
+	}
+
+	// Xiaomi uses region-specific endpoints
+	region := "default"
+	if r, _ := creds.ProviderSpecificData["region"].(string); r != "" {
+		region = r
+	}
+
+	baseURL := "https://api.mimo.xiaomi.com"
+	if b, _ := creds.ProviderSpecificData["baseUrl"].(string); b != "" {
+		baseURL = strings.TrimSuffix(b, "/")
+	}
+	_ = region
+
+	return baseURL + "/v1/chat/completions"
+}
+
+// BuildHeaders sets Xiaomi Tokenplan auth headers.
+func (ex *XiaomiTokenplanExecutor) BuildHeaders(creds Credentials, stream bool) http.Header {
+	h := ex.DefaultExecutor.BuildHeaders(creds, stream)
+
+	if creds.APIKey != "" {
+		h.Set("Authorization", "Bearer "+creds.APIKey)
+	}
+
+	return h
+}
+
+func init() {
+	Register("xiaomi-tokenplan", func(provider string, cfg *ProviderConfig) Executor {
+		return NewXiaomiTokenplanExecutor(provider, cfg)
+	})
+}


### PR DESCRIPTION
## Summary

Ports 11 missing provider executors from Node.js to Go.

### Before: 10 executors (azure, base, codex, cursor, default, github, mimo_free, ollama, vertex, zcode)
### After: 21 executors (2.1x increase)

## New Executors (11 files)

| Executor | Provider | Endpoint |
|----------|----------|----------|
|  | antigravity |  |
|  | codebuddy-cn |  |
|  | commandcode |  |
|  | gemini-cli |  |
|  | grok-web |  |
|  | iflow |  |
|  | kiro |  |
|  | opencode |  |
|  | qoder |  |
|  | qwen |  |
|  | xiaomi-tokenplan |  |

## Implementation

Each executor:
- Registered via  with provider ID
- Implements  with provider-specific endpoint
- Implements  with appropriate auth (Bearer/x-goog-api-key)
- Respects  override
- Falls back to  patterns for retry/fallback

## Tests

- : URL + auth for all 11 executors
- : registry lookup for all 11
- All existing 27 executor tests still pass

## Verification

- `go build ./...` — clean
- `go test ./...` — pass (all packages)
- `go vet ./...` — clean
- `go test ./internal/providers/executors -v` — 38 tests pass

## Note

These are basic executors. Advanced features like:
- Kiro's EventStream format
- Gemini CLI's thinking mode
- Antigravity's Gemini-compatible transform
- Xiaomi's region-specific endpoints

Can be added in follow-up PRs if needed.