### PR TITLE
test: add comprehensive test coverage for translator and log packages

### DIFF
--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -1,0 +1,120 @@
+package log
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	tests := []struct{ level string; ok bool }{
+		{"debug", true},
+		{"info", true},
+		{"warn", true},
+		{"warning", true},
+		{"error", true},
+		{"bogus", false},
+	}
+	for _, tt := range tests {
+		_, err := New(tt.level)
+		if tt.ok && err != nil {
+			t.Errorf("New(%q) unexpected error: %v", tt.level, err)
+		}
+		if !tt.ok && err == nil {
+			t.Errorf("New(%q) expected error, got nil", tt.level)
+		}
+	}
+}
+
+func TestNew_CaseInsensitive(t *testing.T) {
+	_, err := New("DEBUG")
+	if err != nil {
+		t.Errorf("New(\"DEBUG\") unexpected error: %v", err)
+	}
+	_, err = New("Info")
+	if err != nil {
+		t.Errorf("New(\"Info\") unexpected error: %v", err)
+	}
+}
+
+func TestStack(t *testing.T) {
+	s := Stack()
+	if s == "" {
+		t.Error("Stack() returned empty string")
+	}
+	if !strings.Contains(s, "goroutine") {
+		t.Error("Stack() should contain goroutine info")
+	}
+}
+
+func TestRequestLogger(t *testing.T) {
+	logger, _ := New("info")
+	mw := RequestLogger(logger)
+	if mw == nil {
+		t.Fatal("RequestLogger returned nil")
+	}
+
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusTeapot)
+	})
+
+	mw(next).ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/test", nil))
+	if !called {
+		t.Error("next handler not called")
+	}
+}
+
+func TestRecovery(t *testing.T) {
+	logger, _ := New("error")
+	mw := Recovery(logger)
+	if mw == nil {
+		t.Fatal("Recovery returned nil")
+	}
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("test panic")
+	})
+
+	rec := httptest.NewRecorder()
+	mw(next).ServeHTTP(rec, httptest.NewRequest("GET", "/panic", nil))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestRecovery_NoPanic(t *testing.T) {
+	logger, _ := New("error")
+	mw := Recovery(logger)
+
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	rec := httptest.NewRecorder()
+	mw(next).ServeHTTP(rec, httptest.NewRequest("GET", "/safe", nil))
+	if !called {
+		t.Error("next handler not called")
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+func TestResponseWriter(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rw := &responseWriter{ResponseWriter: rec, statusCode: http.StatusOK}
+
+	rw.WriteHeader(http.StatusCreated)
+	if rw.statusCode != http.StatusCreated {
+		t.Errorf("statusCode = %d, want %d", rw.statusCode, http.StatusCreated)
+	}
+	if rec.Code != http.StatusCreated {
+		t.Errorf("underlying status = %d, want %d", rec.Code, http.StatusCreated)
+	}
+}

--- a/internal/translator/concerns/chunk_test.go
+++ b/internal/translator/concerns/chunk_test.go
@@ -1,0 +1,91 @@
+package concerns
+
+import (
+	"testing"
+)
+
+func TestBuildChunk_Basic(t *testing.T) {
+	meta := map[string]any{"id": "chatcmpl-123", "created": 1000, "model": "gpt-4o"}
+	delta := map[string]any{"content": "hello"}
+	chunk := BuildChunk(meta, delta, "")
+	if chunk["id"] != "chatcmpl-123" {
+		t.Errorf("id = %v, want chatcmpl-123", chunk["id"])
+	}
+	if chunk["object"] != "chat.completion.chunk" {
+		t.Errorf("object = %v, want chat.completion.chunk", chunk["object"])
+	}
+	if chunk["created"] != 1000 {
+		t.Errorf("created = %v, want 1000", chunk["created"])
+	}
+	if chunk["model"] != "gpt-4o" {
+		t.Errorf("model = %v, want gpt-4o", chunk["model"])
+	}
+	choices, ok := chunk["choices"].([]map[string]any)
+	if !ok || len(choices) != 1 {
+		t.Fatalf("choices wrong: %v", chunk["choices"])
+	}
+	d, _ := choices[0]["delta"].(map[string]any)
+	if d["content"] != "hello" {
+		t.Errorf("delta mismatch: %v", d)
+	}
+	if choices[0]["finish_reason"] != nil {
+		t.Errorf("finish_reason should be nil, got %v", choices[0]["finish_reason"])
+	}
+}
+
+func TestBuildChunk_WithFinishReason(t *testing.T) {
+	meta := map[string]any{"id": "x", "created": 1, "model": "m"}
+	delta := map[string]any{}
+	chunk := BuildChunk(meta, delta, "stop")
+	choices, _ := chunk["choices"].([]map[string]any)
+	if choices[0]["finish_reason"] != "stop" {
+		t.Errorf("finish_reason = %v, want stop", choices[0]["finish_reason"])
+	}
+}
+
+func TestBuildChunk_NilMeta(t *testing.T) {
+	chunk := BuildChunk(nil, map[string]any{}, "")
+	if chunk["id"] != "" {
+		t.Errorf("id should be empty")
+	}
+	if chunk["created"] != 0 {
+		t.Errorf("created should be 0")
+	}
+}
+
+func TestBuildClaudeChunk(t *testing.T) {
+	chunk := BuildClaudeChunk("content_block_delta", map[string]any{"index": 0})
+	if chunk["type"] != "content_block_delta" {
+		t.Errorf("type = %v, want content_block_delta", chunk["type"])
+	}
+	if chunk["index"] != 0 {
+		t.Errorf("index = %v, want 0", chunk["index"])
+	}
+}
+
+func TestSplitChunk(t *testing.T) {
+	chunk := map[string]any{"a": 1}
+	result := SplitChunk("openai", chunk)
+	if len(result) != 1 {
+		t.Errorf("len = %d, want 1", len(result))
+	}
+	if result[0]["a"] != 1 {
+		t.Errorf("chunk lost data")
+	}
+}
+
+func TestReasoningDelta(t *testing.T) {
+	delta := ReasoningDelta("thinking hard")
+	if delta["reasoning_content"] != "thinking hard" {
+		t.Errorf("reasoning_content = %v", delta["reasoning_content"])
+	}
+	if delta["reasoning"] != "thinking hard" {
+		t.Errorf("reasoning = %v", delta["reasoning"])
+	}
+	if delta["reasoning_type"] != "token" {
+		t.Errorf("reasoning_type = %v", delta["reasoning_type"])
+	}
+	if delta["content"] != "" {
+		t.Errorf("content should be empty")
+	}
+}

--- a/internal/translator/concerns/finishReason_test.go
+++ b/internal/translator/concerns/finishReason_test.go
@@ -1,0 +1,78 @@
+package concerns
+
+import "testing"
+
+func TestToOpenAIFinish_Claude(t *testing.T) {
+	tests := map[string]string{
+		"end_turn":       "stop",
+		"max_tokens":     "length",
+		"stop_sequence":  "stop",
+		"tool_use":       "tool_calls",
+		"content_filter": "content_filter",
+	}
+	for in, want := range tests {
+		got := ToOpenAIFinish(in, "claude")
+		if got != want {
+			t.Errorf("ToOpenAIFinish(%q, claude) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestToOpenAIFinish_Gemini(t *testing.T) {
+	tests := map[string]string{
+		"STOP":           "stop",
+		"MAX_TOKENS":     "length",
+		"SAFETY":         "content_filter",
+		"RECITATION":     "content_filter",
+		"OTHER":          "stop",
+	}
+	for in, want := range tests {
+		got := ToOpenAIFinish(in, "gemini")
+		if got != want {
+			t.Errorf("ToOpenAIFinish(%q, gemini) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestToOpenAIFinish_OpenAI(t *testing.T) {
+	got := ToOpenAIFinish("stop", "openai")
+	if got != "stop" {
+		t.Errorf("ToOpenAIFinish(stop, openai) = %q, want stop", got)
+	}
+}
+
+func TestToOpenAIFinish_Unknown(t *testing.T) {
+	got := ToOpenAIFinish("bogus", "unknown")
+	if got != "bogus" {
+		t.Errorf("ToOpenAIFinish(bogus, unknown) = %q, want bogus", got)
+	}
+}
+
+func TestFromOpenAIFinish_Claude(t *testing.T) {
+	got := FromOpenAIFinish("stop", "claude")
+	if got == "" {
+		t.Error("expected non-empty result")
+	}
+	got = FromOpenAIFinish("length", "claude")
+	if got != "max_tokens" {
+		t.Errorf("FromOpenAIFinish(length, claude) = %q, want max_tokens", got)
+	}
+}
+
+func TestFromOpenAIFinish_Gemini(t *testing.T) {
+	got := FromOpenAIFinish("stop", "gemini")
+	if got == "" {
+		t.Error("expected non-empty result")
+	}
+	got = FromOpenAIFinish("length", "gemini")
+	if got != "MAX_TOKENS" {
+		t.Errorf("FromOpenAIFinish(length, gemini) = %q, want MAX_TOKENS", got)
+	}
+}
+
+func TestMapFinishReason(t *testing.T) {
+	got := MapFinishReason("claude", "end_turn")
+	if got != "stop" {
+		t.Errorf("MapFinishReason(claude, end_turn) = %q, want stop", got)
+	}
+}

--- a/internal/translator/concerns/image_test.go
+++ b/internal/translator/concerns/image_test.go
@@ -1,0 +1,56 @@
+package concerns
+
+import "testing"
+
+func TestEncodeDataUri(t *testing.T) {
+	got := EncodeDataUri("image/png", "aGVsbG8=")
+	if got != "data:image/png;base64,aGVsbG8=" {
+		t.Errorf("EncodeDataUri = %q", got)
+	}
+}
+
+func TestEncodeDataUri_DefaultMime(t *testing.T) {
+	got := EncodeDataUri("", "aGVsbG8=")
+	if got != "data:image/png;base64,aGVsbG8=" {
+		t.Errorf("EncodeDataUri empty mime = %q", got)
+	}
+}
+
+func TestParseDataUri_Valid(t *testing.T) {
+	parsed := ParseDataUri("data:image/jpeg;base64,aGVsbG8=")
+	if parsed == nil {
+		t.Fatal("ParseDataUri returned nil")
+	}
+	if parsed.MimeType != "image/jpeg" {
+		t.Errorf("MimeType = %q, want image/jpeg", parsed.MimeType)
+	}
+	if parsed.Base64 != "aGVsbG8=" {
+		t.Errorf("Base64 = %q, want aGVsbG8=", parsed.Base64)
+	}
+}
+
+func TestParseDataUri_NotDataUri(t *testing.T) {
+	if ParseDataUri("https://example.com/img.png") != nil {
+		t.Error("should return nil for non-data URI")
+	}
+}
+
+func TestParseDataUri_NoBase64(t *testing.T) {
+	if ParseDataUri("data:image/png,raw") != nil {
+		t.Error("should return nil for non-base64")
+	}
+}
+
+func TestParseDataUri_InvalidBase64(t *testing.T) {
+	if ParseDataUri("data:image/png;base64,!!!invalid!!!") != nil {
+		t.Error("should return nil for invalid base64")
+	}
+}
+
+func TestNormalizeImagePart(t *testing.T) {
+	part := map[string]any{"type": "image_url"}
+	out := NormalizeImagePart(part, "")
+	if out["type"] != "image_url" {
+		t.Errorf("type lost")
+	}
+}

--- a/internal/translator/concerns/json_test.go
+++ b/internal/translator/concerns/json_test.go
@@ -1,0 +1,75 @@
+package concerns
+
+import "testing"
+
+func TestParseJSONSchema_Map(t *testing.T) {
+	in := map[string]any{"type": "object"}
+	out, err := ParseJSONSchema(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out["type"] != "object" {
+		t.Errorf("type = %v", out["type"])
+	}
+}
+
+func TestParseJSONSchema_String(t *testing.T) {
+	in := `{"type":"object","properties":{}}`
+	out, err := ParseJSONSchema(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out["type"] != "object" {
+		t.Errorf("type = %v", out["type"])
+	}
+}
+
+func TestParseJSONSchema_InvalidString(t *testing.T) {
+	_, err := ParseJSONSchema("{bad json")
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+func TestParseJSONSchema_UnsupportedType(t *testing.T) {
+	_, err := ParseJSONSchema(123)
+	if err == nil {
+		t.Error("expected error for int")
+	}
+}
+
+func TestSafeParseJSON_Valid(t *testing.T) {
+	out := SafeParseJSON(`{"key":"value"}`, "fallback")
+	m, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map, got %T", out)
+	}
+	if m["key"] != "value" {
+		t.Errorf("key = %v", m["key"])
+	}
+}
+
+func TestSafeParseJSON_Invalid(t *testing.T) {
+	out := SafeParseJSON("not json", "fallback")
+	if out != "fallback" {
+		t.Errorf("expected fallback, got %v", out)
+	}
+}
+
+func TestMarshalJSON(t *testing.T) {
+	s := MarshalJSON(map[string]any{"a": 1})
+	if s != `{"a":1}` {
+		t.Errorf("MarshalJSON = %q", s)
+	}
+}
+
+func TestSafeUnmarshal(t *testing.T) {
+	var out map[string]any
+	err := SafeUnmarshal([]byte(`{"key":"val"}`), &out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out["key"] != "val" {
+		t.Errorf("key = %v", out["key"])
+	}
+}

--- a/internal/translator/concerns/message_test.go
+++ b/internal/translator/concerns/message_test.go
@@ -1,0 +1,111 @@
+package concerns
+
+import "testing"
+
+func TestExtractTextContent_String(t *testing.T) {
+	got := ExtractTextContent("hello world", "\n")
+	if got != "hello world" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExtractTextContent_EmptyString(t *testing.T) {
+	got := ExtractTextContent("", "\n")
+	if got != "" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExtractTextContent_Nil(t *testing.T) {
+	got := ExtractTextContent(nil, "\n")
+	if got != "" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExtractTextContent_StringArray(t *testing.T) {
+	content := []any{
+		map[string]any{"type": "text", "text": "line1"},
+		map[string]any{"type": "image_url", "image_url": "x"},
+		map[string]any{"type": "text", "text": "line2"},
+	}
+	got := ExtractTextContent(content, "\n")
+	if got != "line1\nline2" {
+		t.Errorf("got %q, want line1\\nline2", got)
+	}
+}
+
+func TestExtractTextContent_MapArray(t *testing.T) {
+	content := []map[string]any{
+		{"type": "text", "text": "a"},
+		{"type": "text", "text": "b"},
+	}
+	got := ExtractTextContent(content, "; ")
+	if got != "a; b" {
+		t.Errorf("got %q, want a; b", got)
+	}
+}
+
+func TestExtractTextContent_NoTextParts(t *testing.T) {
+	content := []any{
+		map[string]any{"type": "image_url"},
+	}
+	got := ExtractTextContent(content, "\n")
+	if got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}
+
+func TestCollapseTextParts_Empty(t *testing.T) {
+	got := CollapseTextParts([]map[string]any{})
+	if got != "" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestCollapseTextParts_Single(t *testing.T) {
+	parts := []map[string]any{{"type": "text", "text": "hello"}}
+	got := CollapseTextParts(parts)
+	m, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map, got %T", got)
+	}
+	if m["text"] != "hello" {
+		t.Errorf("text = %v", m["text"])
+	}
+}
+
+func TestCollapseTextParts_Multiple(t *testing.T) {
+	parts := []map[string]any{
+		{"type": "text", "text": "a"},
+		{"type": "text", "text": "b"},
+	}
+	got := CollapseTextParts(parts)
+	m, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map, got %T", got)
+	}
+	if m["text"] != "a\nb" {
+		t.Errorf("text = %v", m["text"])
+	}
+}
+
+func TestDeepCloneMessage(t *testing.T) {
+	orig := map[string]any{"role": "user", "content": "hi"}
+	clone := DeepCloneMessage(orig)
+	if clone["role"] != "user" {
+		t.Errorf("role lost")
+	}
+	clone["role"] = "assistant"
+	if orig["role"] != "user" {
+		t.Error("clone should not modify original")
+	}
+}
+
+func TestNormalizeMessage(t *testing.T) {
+	msg := map[string]any{"role": "user"}
+	out := NormalizeMessage(msg)
+	if out["role"] != "user" {
+		t.Errorf("role lost")
+	}
+}

--- a/internal/translator/concerns/misc_test.go
+++ b/internal/translator/concerns/misc_test.go
@@ -1,0 +1,110 @@
+package concerns
+
+import "testing"
+
+func TestExtractReasoningText_Found(t *testing.T) {
+	delta := map[string]any{"reasoning_content": "thinking deeply"}
+	got := ExtractReasoningText(delta)
+	if got != "thinking deeply" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExtractReasoningText_AlternateKey(t *testing.T) {
+	delta := map[string]any{"reasoning": "alt thinking"}
+	got := ExtractReasoningText(delta)
+	if got != "alt thinking" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExtractReasoningText_ThinkingKey(t *testing.T) {
+	delta := map[string]any{"thinking": "thought"}
+	got := ExtractReasoningText(delta)
+	if got != "thought" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExtractReasoningText_None(t *testing.T) {
+	delta := map[string]any{"content": "regular"}
+	got := ExtractReasoningText(delta)
+	if got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}
+
+func TestExtractReasoningText_WhitespaceOnly(t *testing.T) {
+	delta := map[string]any{"reasoning": "   "}
+	got := ExtractReasoningText(delta)
+	if got != "" {
+		t.Errorf("got %q, want empty for whitespace", got)
+	}
+}
+
+func TestNormalizeReasoning(t *testing.T) {
+	chunk := map[string]any{"a": 1}
+	out := NormalizeReasoning(chunk)
+	if out["a"] != 1 {
+		t.Error("data lost")
+	}
+}
+
+func TestCaptureThinking(t *testing.T) {
+	chunk := map[string]any{"a": 1}
+	out := CaptureThinking(chunk)
+	if out["a"] != 1 {
+		t.Error("data lost")
+	}
+}
+
+func TestApplyThinking(t *testing.T) {
+	body := map[string]any{"a": 1}
+	out := ApplyThinking(body, map[string]any{"budget": 100})
+	if out["a"] != 1 {
+		t.Error("data lost")
+	}
+}
+
+func TestCaptureThinkingUnified(t *testing.T) {
+	chunk := map[string]any{"a": 1}
+	out, changed := CaptureThinkingUnified(chunk, map[string]bool{})
+	if out["a"] != 1 {
+		t.Error("data lost")
+	}
+	if changed {
+		t.Error("should not change")
+	}
+}
+
+func TestApplyThinkingUnified(t *testing.T) {
+	body := map[string]any{"a": 1}
+	out := ApplyThinkingUnified(body, map[string]any{})
+	if out["a"] != 1 {
+		t.Error("data lost")
+	}
+}
+
+func TestFilterModality(t *testing.T) {
+	body := map[string]any{"a": 1}
+	out := FilterModality(body, []string{"text"})
+	if out["a"] != 1 {
+		t.Error("data lost")
+	}
+}
+
+func TestFilterUnsupportedParams(t *testing.T) {
+	body := map[string]any{"a": 1}
+	out := FilterUnsupportedParams(body, map[string]bool{"a": true})
+	if out["a"] != 1 {
+		t.Error("data lost")
+	}
+}
+
+func TestPrefetchImages(t *testing.T) {
+	body := map[string]any{"a": 1}
+	out := PrefetchImages(body)
+	if out["a"] != 1 {
+		t.Error("data lost")
+	}
+}

--- a/internal/translator/concerns/toolCall_test.go
+++ b/internal/translator/concerns/toolCall_test.go
@@ -1,0 +1,119 @@
+package concerns
+
+import "testing"
+
+func TestEnsureToolCallIds_GeneratesMissing(t *testing.T) {
+	tcs := []map[string]any{
+		{"id": "", "function": map[string]any{"name": "foo"}},
+		{"id": "call_123", "function": map[string]any{"name": "bar"}},
+	}
+	out := EnsureToolCallIds(tcs)
+	if out[0]["id"] == "" {
+		t.Error("id should be generated")
+	}
+	if out[1]["id"] != "call_123" {
+		t.Error("existing id should be preserved")
+	}
+}
+
+func TestEnsureToolCallIds_NilId(t *testing.T) {
+	tcs := []map[string]any{
+		{"function": map[string]any{"name": "foo"}},
+	}
+	out := EnsureToolCallIds(tcs)
+	id, ok := out[0]["id"].(string)
+	if !ok || id == "" {
+		t.Error("id should be generated")
+	}
+}
+
+func TestEnsureToolCallIds_AllPresent(t *testing.T) {
+	tcs := []map[string]any{
+		{"id": "call_a"},
+		{"id": "call_b"},
+	}
+	out := EnsureToolCallIds(tcs)
+	if out[0]["id"] != "call_a" || out[1]["id"] != "call_b" {
+		t.Error("ids should be unchanged")
+	}
+}
+
+func TestEnsureToolCallIds_Empty(t *testing.T) {
+	out := EnsureToolCallIds([]map[string]any{})
+	if len(out) != 0 {
+		t.Error("should be empty")
+	}
+}
+
+func TestFallbackToolCallID(t *testing.T) {
+	id := FallbackToolCallID()
+	if len(id) < 10 {
+		t.Errorf("id too short: %q", id)
+	}
+	if id[:5] != "call_" {
+		t.Errorf("id should start with call_: %q", id)
+	}
+}
+
+func TestEnsureToolCallIdsInBody(t *testing.T) {
+	body := map[string]any{
+		"messages": []map[string]any{
+			{"role": "assistant", "tool_calls": []map[string]any{
+				{"id": "", "function": map[string]any{"name": "foo"}},
+			}},
+		},
+	}
+	EnsureToolCallIdsInBody(body)
+	msgs := body["messages"].([]map[string]any)
+	tcs := msgs[0]["tool_calls"].([]map[string]any)
+	if tcs[0]["id"] == "" {
+		t.Error("id should be generated")
+	}
+}
+
+func TestEnsureToolCallIdsInBody_NoMessages(t *testing.T) {
+	body := map[string]any{}
+	EnsureToolCallIdsInBody(body) // should not panic
+}
+
+func TestFixMissingToolResponses_NoMissing(t *testing.T) {
+	msgs := []map[string]any{
+		{"role": "assistant", "tool_calls": []map[string]any{{"id": "call_1"}}},
+		{"role": "tool", "tool_call_id": "call_1", "content": "result"},
+	}
+	out := FixMissingToolResponses(msgs)
+	if len(out) != 2 {
+		t.Errorf("len = %d, want 2", len(out))
+	}
+}
+
+func TestFixMissingToolResponses_MissingResponse(t *testing.T) {
+	msgs := []map[string]any{
+		{"role": "assistant", "tool_calls": []map[string]any{
+			{"id": "call_1"},
+			{"id": "call_2"},
+		}},
+		{"role": "tool", "tool_call_id": "call_1", "content": "result1"},
+	}
+	out := FixMissingToolResponses(msgs)
+	if len(out) != 3 {
+		t.Errorf("len = %d, want 3", len(out))
+	}
+	last := out[2]
+	if last["role"] != "tool" {
+		t.Errorf("last role = %v", last["role"])
+	}
+	if last["tool_call_id"] != "call_2" {
+		t.Errorf("tool_call_id = %v", last["tool_call_id"])
+	}
+}
+
+func TestFixMissingToolResponses_NoToolCalls(t *testing.T) {
+	msgs := []map[string]any{
+		{"role": "user", "content": "hi"},
+	}
+	out := FixMissingToolResponses(msgs)
+	if len(out) != 1 {
+		t.Errorf("len = %d, want 1", len(out))
+	}
+}

--- a/internal/translator/concerns/usage_test.go
+++ b/internal/translator/concerns/usage_test.go
@@ -1,0 +1,148 @@
+package concerns
+
+import "testing"
+
+func TestIntNumber_Int(t *testing.T) {
+	if IntNumber(42) != 42 {
+		t.Errorf("IntNumber(42) = %d", IntNumber(42))
+	}
+}
+
+func TestIntNumber_Float64(t *testing.T) {
+	if IntNumber(float64(3.9)) != 3 {
+		t.Errorf("IntNumber(3.9) = %d", IntNumber(float64(3.9)))
+	}
+}
+
+func TestIntNumber_Int64(t *testing.T) {
+	if IntNumber(int64(100)) != 100 {
+		t.Errorf("IntNumber(int64(100)) = %d", IntNumber(int64(100)))
+	}
+}
+
+func TestIntNumber_Float32(t *testing.T) {
+	if IntNumber(float32(5.5)) != 5 {
+		t.Errorf("IntNumber(float32(5.5)) = %d", IntNumber(float32(5.5)))
+	}
+}
+
+func TestIntNumber_Nil(t *testing.T) {
+	if IntNumber(nil) != 0 {
+		t.Errorf("IntNumber(nil) = %d", IntNumber(nil))
+	}
+}
+
+func TestIntNumber_String(t *testing.T) {
+	if IntNumber("abc") != 0 {
+		t.Errorf("IntNumber(abc) = %d", IntNumber("abc"))
+	}
+}
+
+func TestToOpenAIUsage_ClaudeFormat(t *testing.T) {
+	usage := map[string]any{
+		"input_tokens":               100,
+		"output_tokens":              50,
+		"cache_read_input_tokens":    10,
+		"cache_creation_input_tokens": 5,
+	}
+	out := ToOpenAIUsage(usage, "claude")
+	if out["prompt_tokens"] != 115 {
+		t.Errorf("prompt_tokens = %v, want 115", out["prompt_tokens"])
+	}
+	if out["completion_tokens"] != 50 {
+		t.Errorf("completion_tokens = %v, want 50", out["completion_tokens"])
+	}
+	if out["total_tokens"] != 165 {
+		t.Errorf("total_tokens = %v, want 165", out["total_tokens"])
+	}
+	if out["cache_read_input_tokens"] != 10 {
+		t.Errorf("cache_read_input_tokens = %v", out["cache_read_input_tokens"])
+	}
+	if out["cache_creation_input_tokens"] != 5 {
+		t.Errorf("cache_creation_input_tokens = %v", out["cache_creation_input_tokens"])
+	}
+}
+
+func TestToOpenAIUsage_OpenAIFormat(t *testing.T) {
+	usage := map[string]any{
+		"prompt_tokens":     200,
+		"completion_tokens": 100,
+	}
+	out := ToOpenAIUsage(usage, "openai")
+	if out["prompt_tokens"] != 200 {
+		t.Errorf("prompt_tokens = %v", out["prompt_tokens"])
+	}
+	if out["completion_tokens"] != 100 {
+		t.Errorf("completion_tokens = %v", out["completion_tokens"])
+	}
+	if out["total_tokens"] != 300 {
+		t.Errorf("total_tokens = %v, want 300", out["total_tokens"])
+	}
+}
+
+func TestToOpenAIUsage_Nil(t *testing.T) {
+	if ToOpenAIUsage(nil, "openai") != nil {
+		t.Error("expected nil")
+	}
+}
+
+func TestMergeUsage_NilDst(t *testing.T) {
+	src := map[string]any{"a": 1}
+	out := MergeUsage(nil, src)
+	if out["a"] != 1 {
+		t.Errorf("a = %v", out["a"])
+	}
+}
+
+func TestMergeUsage_Existing(t *testing.T) {
+	dst := map[string]any{"a": 1}
+	src := map[string]any{"b": 2}
+	out := MergeUsage(dst, src)
+	if out["a"] != 1 {
+		t.Errorf("a = %v", out["a"])
+	}
+	if out["b"] != 2 {
+		t.Errorf("b = %v", out["b"])
+	}
+}
+
+func TestBuildUsage_Basic(t *testing.T) {
+	u := BuildUsage(10, 20, 30, 0, 0, 0)
+	if u["prompt_tokens"] != 10 {
+		t.Errorf("prompt = %v", u["prompt_tokens"])
+	}
+	if u["completion_tokens"] != 20 {
+		t.Errorf("completion = %v", u["completion_tokens"])
+	}
+	if u["total_tokens"] != 30 {
+		t.Errorf("total = %v", u["total_tokens"])
+	}
+	if _, ok := u["prompt_tokens_details"]; ok {
+		t.Error("should not have details when all 0")
+	}
+}
+
+func TestBuildUsage_WithDetails(t *testing.T) {
+	u := BuildUsage(10, 20, 30, 5, 3, 0)
+	details, ok := u["prompt_tokens_details"].(map[string]any)
+	if !ok {
+		t.Fatal("missing prompt_tokens_details")
+	}
+	if details["cached_tokens"] != 5 {
+		t.Errorf("cached = %v", details["cached_tokens"])
+	}
+	if details["cache_creation_tokens"] != 3 {
+		t.Errorf("cache_creation = %v", details["cache_creation_tokens"])
+	}
+}
+
+func TestBuildUsage_WithReasoning(t *testing.T) {
+	u := BuildUsage(10, 20, 30, 0, 0, 7)
+	details, ok := u["completion_tokens_details"].(map[string]any)
+	if !ok {
+		t.Fatal("missing completion_tokens_details")
+	}
+	if details["reasoning_tokens"] != 7 {
+		t.Errorf("reasoning = %v", details["reasoning_tokens"])
+	}
+}

--- a/internal/translator/formats/formats_test.go
+++ b/internal/translator/formats/formats_test.go
@@ -1,0 +1,96 @@
+package formats
+
+import "testing"
+
+func TestFilterToOpenAIFormat(t *testing.T) {
+	body := map[string]any{"model": "gpt-4o", "messages": []any{}}
+	out := FilterToOpenAIFormat(body, false)
+	if out["model"] != "gpt-4o" {
+		t.Errorf("model lost: %v", out["model"])
+	}
+}
+
+func TestPrepareClaudeRequest(t *testing.T) {
+	body := map[string]any{"model": "claude-4", "messages": []any{}}
+	out := PrepareClaudeRequest(body, "claude-4", false)
+	if out["model"] != "claude-4" {
+		t.Errorf("model lost: %v", out["model"])
+	}
+}
+
+func TestGeminiConstants(t *testing.T) {
+	if GeminiAPIVersion != "v1beta" {
+		t.Errorf("GeminiAPIVersion = %q, want v1beta", GeminiAPIVersion)
+	}
+	if GeminiGenerateContentPath != "generateContent" {
+		t.Errorf("GeminiGenerateContentPath = %q, want generateContent", GeminiGenerateContentPath)
+	}
+	if GeminiStreamGenerateContentPath != "streamGenerateContent" {
+		t.Errorf("GeminiStreamGenerateContentPath = %q, want streamGenerateContent", GeminiStreamGenerateContentPath)
+	}
+}
+
+func TestResponsesApiConstants(t *testing.T) {
+	if OpenAIResponsesAPIVersion != "v1" {
+		t.Errorf("OpenAIResponsesAPIVersion = %q, want v1", OpenAIResponsesAPIVersion)
+	}
+	if OpenAIResponsesEndpoint != "responses" {
+		t.Errorf("OpenAIResponsesEndpoint = %q, want responses", OpenAIResponsesEndpoint)
+	}
+}
+
+func TestAdjustMaxTokens_Default(t *testing.T) {
+	body := map[string]any{}
+	got := AdjustMaxTokens(body)
+	if got != DefaultMaxTokens {
+		t.Errorf("AdjustMaxTokens(empty) = %d, want %d", got, DefaultMaxTokens)
+	}
+}
+
+func TestAdjustMaxTokens_Explicit(t *testing.T) {
+	body := map[string]any{"max_tokens": 1000}
+	got := AdjustMaxTokens(body)
+	if got != 1000 {
+		t.Errorf("AdjustMaxTokens(1000) = %d, want 1000", got)
+	}
+}
+
+func TestAdjustMaxTokens_ZeroBecomesDefault(t *testing.T) {
+	body := map[string]any{"max_tokens": 0}
+	got := AdjustMaxTokens(body)
+	if got != DefaultMaxTokens {
+		t.Errorf("AdjustMaxTokens(0) = %d, want %d", got, DefaultMaxTokens)
+	}
+}
+
+func TestAdjustMaxTokens_ToolsBoost(t *testing.T) {
+	body := map[string]any{"max_tokens": 100, "tools": []any{map[string]any{"type": "function"}}}
+	got := AdjustMaxTokens(body)
+	if got != DefaultMinTokens {
+		t.Errorf("AdjustMaxTokens with tools = %d, want %d (min)", got, DefaultMinTokens)
+	}
+}
+
+func TestAdjustMaxTokens_ThinkingBudget(t *testing.T) {
+	body := map[string]any{"max_tokens": 100, "thinking": map[string]any{"budget_tokens": 5000}}
+	got := AdjustMaxTokens(body)
+	if got != 6024 {
+		t.Errorf("AdjustMaxTokens with thinking budget = %d, want 6024", got)
+	}
+}
+
+func TestAdjustMaxTokens_CappedAtDefault(t *testing.T) {
+	body := map[string]any{"max_tokens": 999999}
+	got := AdjustMaxTokens(body)
+	if got != DefaultMaxTokens {
+		t.Errorf("AdjustMaxTokens(999999) = %d, want %d (capped)", got, DefaultMaxTokens)
+	}
+}
+
+func TestAdjustMaxTokens_FloatCoercion(t *testing.T) {
+	body := map[string]any{"max_tokens": float64(2000)}
+	got := AdjustMaxTokens(body)
+	if got != 2000 {
+		t.Errorf("AdjustMaxTokens(float64 2000) = %d, want 2000", got)
+	}
+}

--- a/internal/translator/request/request_test.go
+++ b/internal/translator/request/request_test.go
@@ -1,0 +1,312 @@
+package request
+
+import (
+	"testing"
+
+	"github.com/9router/9router/internal/translator"
+)
+
+func TestOpenAIToClaude_Basic(t *testing.T) {
+	body := map[string]any{
+		"model":    "gpt-4o",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Hello"},
+		},
+	}
+	out, err := translator.TranslateRequest(
+		translator.FormatOpenAI, translator.FormatClaude,
+		"claude-4", body, false, nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out["model"] != "claude-4" {
+		t.Errorf("model = %v, want claude-4", out["model"])
+	}
+	if out["max_tokens"] == nil {
+		t.Error("max_tokens should be set")
+	}
+	msgs, ok := out["messages"].([]map[string]any)
+	if !ok || len(msgs) != 1 {
+		t.Fatalf("messages wrong: %v", out["messages"])
+	}
+	if msgs[0]["role"] != "user" {
+		t.Errorf("role = %v", msgs[0]["role"])
+	}
+}
+
+func TestOpenAIToClaude_SystemPrompt(t *testing.T) {
+	body := map[string]any{
+		"messages": []any{
+			map[string]any{"role": "system", "content": "You are helpful"},
+			map[string]any{"role": "user", "content": "Hi"},
+		},
+	}
+	out, err := translator.TranslateRequest(
+		translator.FormatOpenAI, translator.FormatClaude,
+		"claude-4", body, false, nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sys, ok := out["system"].([]map[string]any)
+	if !ok || len(sys) == 0 {
+		t.Fatalf("system prompt should be extracted, got: %T", out["system"])
+	}
+}
+
+func TestOpenAIToClaude_WithTools(t *testing.T) {
+	body := map[string]any{
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Use a tool"},
+		},
+		"tools": []any{
+			map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name": "get_weather",
+					"parameters": map[string]any{"type": "object"},
+				},
+			},
+		},
+	}
+	out, err := translator.TranslateRequest(
+		translator.FormatOpenAI, translator.FormatClaude,
+		"claude-4", body, false, nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	tools, ok := out["tools"].([]map[string]any)
+	if !ok || len(tools) != 1 {
+		t.Fatalf("tools wrong: %v", out["tools"])
+	}
+	if tools[0]["name"] != "get_weather" {
+		t.Errorf("tool name = %v", tools[0]["name"])
+	}
+}
+
+func TestOpenAIToClaude_StreamFlag(t *testing.T) {
+	body := map[string]any{
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Hi"},
+		},
+	}
+	out, err := translator.TranslateRequest(
+		translator.FormatOpenAI, translator.FormatClaude,
+		"claude-4", body, true, nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out["stream"] != true {
+		t.Error("stream should be true")
+	}
+}
+
+func TestOpenAIToClaude_Temperature(t *testing.T) {
+	body := map[string]any{
+		"messages":    []any{map[string]any{"role": "user", "content": "Hi"}},
+		"temperature": float64(0.7),
+	}
+	out, err := translator.TranslateRequest(
+		translator.FormatOpenAI, translator.FormatClaude,
+		"claude-4", body, false, nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out["temperature"] != float64(0.7) {
+		t.Errorf("temperature = %v, want 0.7", out["temperature"])
+	}
+}
+
+func TestOpenAIToOllama_Basic(t *testing.T) {
+	body := map[string]any{
+		"model":    "llama3",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Hello"},
+		},
+	}
+	out, err := translator.TranslateRequest(
+		translator.FormatOpenAI, translator.FormatOllama,
+		"llama3", body, false, nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out["model"] != "llama3" {
+		t.Errorf("model = %v", out["model"])
+	}
+}
+
+func TestOpenAIToGemini_Basic(t *testing.T) {
+	body := map[string]any{
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Hello"},
+		},
+	}
+	out, err := translator.TranslateRequest(
+		translator.FormatOpenAI, translator.FormatGemini,
+		"gemini-1.5-pro", body, false, nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out["model"] != "gemini-1.5-pro" {
+		t.Errorf("model = %v", out["model"])
+	}
+}
+
+func TestOpenAIToVertex_Basic(t *testing.T) {
+	body := map[string]any{
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Hello"},
+		},
+	}
+	out, err := translator.TranslateRequest(
+		translator.FormatOpenAI, translator.FormatVertex,
+		"gemini-1.5-pro", body, false, nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out == nil {
+		t.Error("expected non-nil result")
+	}
+}
+
+func TestOpenAIToCursor_Basic(t *testing.T) {
+	body := map[string]any{
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Hello"},
+		},
+	}
+	out, err := translator.TranslateRequest(
+		translator.FormatOpenAI, translator.FormatCursor,
+		"gpt-4o", body, false, nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out == nil {
+		t.Error("expected non-nil result")
+	}
+}
+
+func TestOpenAIToCommandCode_Basic(t *testing.T) {
+	body := map[string]any{
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Hello"},
+		},
+	}
+	out, err := translator.TranslateRequest(
+		translator.FormatOpenAI, translator.FormatCommandCode,
+		"model", body, false, nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out == nil {
+		t.Error("expected non-nil result")
+	}
+}
+
+func TestAntigravityToOpenAI_Basic(t *testing.T) {
+	body := map[string]any{
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Hello"},
+		},
+	}
+	out, err := translator.TranslateRequest(
+		translator.FormatAntigravity, translator.FormatOpenAI,
+		"model", body, false, nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out == nil {
+		t.Error("expected non-nil result")
+	}
+}
+
+func TestOpenAIToClaude_MultiTurnWithAssistant(t *testing.T) {
+	body := map[string]any{
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Hello"},
+			map[string]any{"role": "assistant", "content": "Hi there"},
+			map[string]any{"role": "user", "content": "How are you?"},
+		},
+	}
+	out, err := translator.TranslateRequest(
+		translator.FormatOpenAI, translator.FormatClaude,
+		"claude-4", body, false, nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	msgs, ok := out["messages"].([]map[string]any)
+	if !ok {
+		t.Fatalf("messages wrong type: %T", out["messages"])
+	}
+	if len(msgs) != 3 {
+		t.Errorf("messages len = %d, want 3", len(msgs))
+	}
+}
+
+func TestOpenAIToClaude_EmptyMessages(t *testing.T) {
+	body := map[string]any{
+		"messages": []any{},
+	}
+	_, err := translator.TranslateRequest(
+		translator.FormatOpenAI, translator.FormatClaude,
+		"claude-4", body, false, nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestOpenAIToClaude_ToolCallInAssistant(t *testing.T) {
+	body := map[string]any{
+		"messages": []any{
+			map[string]any{
+				"role": "assistant",
+				"tool_calls": []any{
+					map[string]any{
+						"id": "call_1",
+						"function": map[string]any{
+							"name": "get_weather",
+							"arguments": `{"city":"London"}`,
+						},
+					},
+				},
+			},
+			map[string]any{
+				"role": "tool",
+				"tool_call_id": "call_1",
+				"content": "Sunny, 20C",
+			},
+		},
+	}
+	out, err := translator.TranslateRequest(
+		translator.FormatOpenAI, translator.FormatClaude,
+		"claude-4", body, false, nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out == nil {
+		t.Error("expected non-nil")
+	}
+}
+
+func TestNoTranslator_UnsupportedPair(t *testing.T) {
+	_, err := translator.TranslateRequest(
+		translator.FormatOpenAI, "bogus",
+		"model", map[string]any{}, false, nil,
+	)
+	if err == nil {
+		t.Error("expected error for unsupported pair")
+	}
+}

--- a/internal/translator/response/response_test.go
+++ b/internal/translator/response/response_test.go
@@ -1,0 +1,296 @@
+package response
+
+import (
+	"testing"
+
+	"github.com/9router/9router/internal/translator"
+)
+
+func makeState() *translator.State {
+	return &translator.State{
+		MessageID: "test-123",
+		Model:     "claude-4",
+	}
+}
+
+func TestClaudeToOpenAI_NilChunk(t *testing.T) {
+	state := makeState()
+	out, err := translator.TranslateResponse(
+		translator.FormatClaude, translator.FormatOpenAI,
+		nil, state,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != nil {
+		t.Errorf("expected nil for nil chunk, got %v", out)
+	}
+}
+
+func TestClaudeToOpenAI_MessageStart(t *testing.T) {
+	state := makeState()
+	chunk := map[string]any{
+		"type": "message_start",
+		"message": map[string]any{
+			"id": "msg_123",
+		},
+	}
+	out, err := translator.TranslateResponse(
+		translator.FormatClaude, translator.FormatOpenAI,
+		chunk, state,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) == 0 {
+		t.Error("expected at least one chunk")
+	}
+}
+
+func TestClaudeToOpenAI_ContentBlockDelta(t *testing.T) {
+	state := makeState()
+	chunk := map[string]any{
+		"type":  "content_block_delta",
+		"index": 0,
+		"delta": map[string]any{
+			"type": "text_delta",
+			"text": "Hello",
+		},
+	}
+	out, err := translator.TranslateResponse(
+		translator.FormatClaude, translator.FormatOpenAI,
+		chunk, state,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("expected at least one chunk")
+	}
+	// Should contain content delta
+	chunk0 := out[0]
+	choices, ok := chunk0["choices"].([]map[string]any)
+	if !ok || len(choices) == 0 {
+		t.Fatal("missing choices")
+	}
+	delta, _ := choices[0]["delta"].(map[string]any)
+	if delta["content"] != "Hello" {
+		t.Errorf("content = %v, want Hello", delta["content"])
+	}
+}
+
+func TestClaudeToOpenAI_MessageStop(t *testing.T) {
+	state := makeState()
+	// Send message_start first so state is initialized
+	startChunk := map[string]any{
+		"type": "message_start",
+		"message": map[string]any{
+			"id": "msg_123",
+			"stop_reason": "end_turn",
+		},
+	}
+	_, _ = translator.TranslateResponse(
+		translator.FormatClaude, translator.FormatOpenAI,
+		startChunk, state,
+	)
+	// Now send message_stop
+	chunk := map[string]any{
+		"type": "message_stop",
+	}
+	out, err := translator.TranslateResponse(
+		translator.FormatClaude, translator.FormatOpenAI,
+		chunk, state,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("expected at least one chunk")
+	}
+}
+
+func TestClaudeToOpenAI_MessageDelta_Usage(t *testing.T) {
+	state := makeState()
+	chunk := map[string]any{
+		"type": "message_delta",
+		"usage": map[string]any{
+			"input_tokens":  10,
+			"output_tokens": 20,
+		},
+	}
+	out, err := translator.TranslateResponse(
+		translator.FormatClaude, translator.FormatOpenAI,
+		chunk, state,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state.Usage == nil {
+		t.Error("usage should be captured in state")
+	}
+	_ = out
+}
+
+func TestOllamaToOpenAI_Basic(t *testing.T) {
+	state := &translator.State{
+		MessageID: "test-ollama",
+		Model:     "llama3",
+	}
+	chunk := map[string]any{
+		"message": map[string]any{
+			"role":    "assistant",
+			"content": "Hello",
+		},
+		"done": false,
+	}
+	out, err := translator.TranslateResponse(
+		translator.FormatOllama, translator.FormatOpenAI,
+		chunk, state,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("expected at least one chunk")
+	}
+}
+
+func TestGeminiToOpenAI_Basic(t *testing.T) {
+	state := &translator.State{
+		MessageID: "test-gemini",
+		Model:     "gemini-1.5-pro",
+	}
+	chunk := map[string]any{
+		"candidates": []any{
+			map[string]any{
+				"content": map[string]any{
+					"parts": []any{
+						map[string]any{"text": "Hello"},
+					},
+					"role": "model",
+				},
+			},
+		},
+	}
+	out, err := translator.TranslateResponse(
+		translator.FormatGemini, translator.FormatOpenAI,
+		chunk, state,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("expected at least one chunk")
+	}
+}
+
+func TestCursorToOpenAI_Basic(t *testing.T) {
+	state := &translator.State{
+		MessageID: "test-cursor",
+		Model:     "gpt-4o",
+	}
+	chunk := map[string]any{
+		"choices": []any{
+			map[string]any{
+				"delta": map[string]any{"content": "Hi"},
+				"index": 0,
+			},
+		},
+	}
+	out, err := translator.TranslateResponse(
+		translator.FormatCursor, translator.FormatOpenAI,
+		chunk, state,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("expected at least one chunk")
+	}
+}
+
+func TestCommandCodeToOpenAI_Basic(t *testing.T) {
+	state := &translator.State{
+		MessageID: "test-cc",
+		Model:     "model",
+	}
+	// CommandCode passes through OpenAI-formatted chunks
+	chunk := map[string]any{
+		"object": "chat.completion.chunk",
+		"choices": []any{
+			map[string]any{
+				"delta": map[string]any{"content": "Hi"},
+				"index": 0,
+			},
+		},
+	}
+	out, err := translator.TranslateResponse(
+		translator.FormatCommandCode, translator.FormatOpenAI,
+		chunk, state,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("expected at least one chunk")
+	}
+}
+
+func TestOpenAIToAntigravity_Basic(t *testing.T) {
+	state := &translator.State{
+		MessageID: "test-ag",
+		Model:     "model",
+	}
+	chunk := map[string]any{
+		"choices": []any{
+			map[string]any{
+				"delta": map[string]any{"content": "Hi"},
+				"index": 0,
+			},
+		},
+	}
+	out, err := translator.TranslateResponse(
+		translator.FormatOpenAI, translator.FormatAntigravity,
+		chunk, state,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_ = out
+}
+
+func TestOpenAIToClaude_Basic(t *testing.T) {
+	state := &translator.State{
+		MessageID:         "test-o2c",
+		Model:             "claude-4",
+		NextBlockIndex:    0,
+		TextBlockIndex:    0,
+	}
+	chunk := map[string]any{
+		"choices": []any{
+			map[string]any{
+				"delta": map[string]any{"content": "Hello"},
+				"index": 0,
+			},
+		},
+	}
+	out, err := translator.TranslateResponse(
+		translator.FormatOpenAI, translator.FormatClaude,
+		chunk, state,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_ = out
+}
+
+func TestUnsupportedResponsePair(t *testing.T) {
+	state := makeState()
+	_, err := translator.TranslateResponse(
+		"bogus", translator.FormatOpenAI,
+		map[string]any{}, state,
+	)
+	if err == nil {
+		t.Error("expected error for unsupported pair")
+	}
+}

--- a/internal/translator/schema/schema_test.go
+++ b/internal/translator/schema/schema_test.go
@@ -1,0 +1,156 @@
+package schema
+
+import "testing"
+
+func TestRoleConstants(t *testing.T) {
+	tests := []struct{ name, expected string }{
+		{"RoleSystem", "system"},
+		{"RoleUser", "user"},
+		{"RoleAssistant", "assistant"},
+		{"RoleTool", "tool"},
+		{"GeminiRoleUser", "user"},
+		{"GeminiRoleModel", "model"},
+		{"GeminiRoleFunction", "function"},
+	}
+	if RoleSystem != "system" {
+		t.Errorf("RoleSystem = %q, want %q", RoleSystem, "system")
+	}
+	if RoleUser != "user" {
+		t.Errorf("RoleUser = %q, want %q", RoleUser, "user")
+	}
+	if RoleAssistant != "assistant" {
+		t.Errorf("RoleAssistant = %q, want %q", RoleAssistant, "assistant")
+	}
+	if RoleTool != "tool" {
+		t.Errorf("RoleTool = %q, want %q", RoleTool, "tool")
+	}
+	if GeminiRoleUser != "user" {
+		t.Errorf("GeminiRoleUser = %q, want %q", GeminiRoleUser, "user")
+	}
+	if GeminiRoleModel != "model" {
+		t.Errorf("GeminiRoleModel = %q, want %q", GeminiRoleModel, "model")
+	}
+	if GeminiRoleFunction != "function" {
+		t.Errorf("GeminiRoleFunction = %q, want %q", GeminiRoleFunction, "function")
+	}
+	_ = tests
+}
+
+func TestBlockTypeConstants(t *testing.T) {
+	checks := map[string]string{
+		"OpenAIBlockTypeText":       OpenAIBlockTypeText,
+		"OpenAIBlockTypeImageURL":   OpenAIBlockTypeImageURL,
+		"OpenAIBlockTypeInputAudio": OpenAIBlockTypeInputAudio,
+		"OpenAIBlockTypeRefusal":    OpenAIBlockTypeRefusal,
+		"OpenAIBlockTypeFunction":   OpenAIBlockTypeFunction,
+		"OpenAIBlockTypeImage":      OpenAIBlockTypeImage,
+		"OpenAIBlockTypeFile":       OpenAIBlockTypeFile,
+		"ClaudeBlockTypeText":       ClaudeBlockTypeText,
+		"ClaudeBlockTypeImage":      ClaudeBlockTypeImage,
+		"ClaudeBlockTypeToolUse":    ClaudeBlockTypeToolUse,
+		"ClaudeBlockTypeToolResult": ClaudeBlockTypeToolResult,
+		"ClaudeBlockTypeThinking":   ClaudeBlockTypeThinking,
+		"ClaudeBlockTypeDocument":   ClaudeBlockTypeDocument,
+	}
+	for name, val := range checks {
+		if val == "" {
+			t.Errorf("%s is empty", name)
+		}
+	}
+}
+
+func TestValidOpenAIContentTypes(t *testing.T) {
+	if len(ValidOpenAIContentTypes) != 4 {
+		t.Errorf("ValidOpenAIContentTypes len = %d, want 4", len(ValidOpenAIContentTypes))
+	}
+	found := map[string]bool{}
+	for _, ct := range ValidOpenAIContentTypes {
+		found[ct] = true
+	}
+	for _, want := range []string{"text", "image_url", "input_audio", "refusal"} {
+		if !found[want] {
+			t.Errorf("ValidOpenAIContentTypes missing %q", want)
+		}
+	}
+}
+
+func TestValidOpenAIMessageTypes(t *testing.T) {
+	if len(ValidOpenAIMessageTypes) != 4 {
+		t.Errorf("ValidOpenAIMessageTypes len = %d, want 4", len(ValidOpenAIMessageTypes))
+	}
+}
+
+func TestModelFallback(t *testing.T) {
+	checks := map[string]string{
+		"claude": "claude-sonnet-4-20250514",
+		"openai": "gpt-4o",
+		"gemini": "gemini-1.5-pro-latest",
+		"vertex": "gemini-1.5-pro-latest",
+		"ollama": "llama3",
+	}
+	for key, want := range checks {
+		if got, ok := ModelFallback[key]; !ok {
+			t.Errorf("ModelFallback missing key %q", key)
+		} else if got != want {
+			t.Errorf("ModelFallback[%q] = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestDefaultImageMIME(t *testing.T) {
+	if DefaultImageMIME != "image/png" {
+		t.Errorf("DefaultImageMIME = %q, want %q", DefaultImageMIME, "image/png")
+	}
+}
+
+func TestOpenAIFinishReason(t *testing.T) {
+	checks := map[string]string{
+		"stop":            "stop",
+		"length":          "length",
+		"tool_calls":      "tool_calls",
+		"content_filter":  "content_filter",
+		"function_call":   "function_call",
+	}
+	for in, want := range checks {
+		if got, ok := OpenAIFinishReason[in]; !ok {
+			t.Errorf("OpenAIFinishReason missing %q", in)
+		} else if got != want {
+			t.Errorf("OpenAIFinishReason[%q] = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestClaudeStopReason(t *testing.T) {
+	checks := map[string]string{
+		"end_turn":       "stop",
+		"max_tokens":     "length",
+		"stop_sequence":  "stop",
+		"tool_use":       "tool_calls",
+		"content_filter": "content_filter",
+	}
+	for in, want := range checks {
+		if got, ok := ClaudeStopReason[in]; !ok {
+			t.Errorf("ClaudeStopReason missing %q", in)
+		} else if got != want {
+			t.Errorf("ClaudeStopReason[%q] = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestGeminiFinishReason(t *testing.T) {
+	checks := map[string]string{
+		"STOP":                     "stop",
+		"MAX_TOKENS":               "length",
+		"SAFETY":                   "content_filter",
+		"RECITATION":               "content_filter",
+		"OTHER":                    "stop",
+		"FINISH_REASON_UNSPECIFIED": "stop",
+	}
+	for in, want := range checks {
+		if got, ok := GeminiFinishReason[in]; !ok {
+			t.Errorf("GeminiFinishReason missing %q", in)
+		} else if got != want {
+			t.Errorf("GeminiFinishReason[%q] = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Add test coverage for 6 previously untested packages:

- **internal/translator/schema** (4 src files, 9 tests)
- **internal/translator/formats** (5 src files, 11 tests)  
- **internal/translator/concerns** (13 src files, 75 tests)
- **internal/translator/request** (9 src files, 15 tests)
- **internal/translator/response** (8 src files, 12 tests)
- **internal/log** (2 src files, 7 tests)

Total: **129 new test cases**, all passing.

Full suite: 27 packages, 0 FAIL, 0 SKIP.  go vet: CLEAN.

## Test Coverage Highlights

- Request/response translator round-trips
- Chunk building and parsing
- Finish reason mapping (OpenAI/Claude/Gemini)
- Message extraction and normalization
- Tool call handling and ID generation
- Usage token merging
- JSON schema parsing
- Log middleware recovery and request logging