### PR TITLE
feat(dashboard): wire real DB-backed data into 4 stub handlers

### DIFF
--- a/internal/api/dashboard/stubs.go
+++ b/internal/api/dashboard/stubs.go
@@ -2,8 +2,10 @@ package dashboard
 
 import (
 	"encoding/json"
+	"strings"
 	"net/http"
 
+	"github.com/9router/9router/internal/db/repos"
 	"github.com/9router/9router/internal/models"
 	"github.com/9router/9router/internal/network"
 )
@@ -15,12 +17,16 @@ type StubsHandlers struct {
 	// Builder is the model list builder, used by ModelsList to serve the
 	// /api/models route with real data instead of an empty stub.
 	Builder *models.Builder
+
+	// Repos provides access to DB-backed data for stubs that can serve
+	// real values. Optional — pass nil to keep static stub behavior.
+	Repos *repos.Repos
 }
 
 // NewStubsHandlers creates stub handlers. The builder parameter is optional;
 // pass nil to keep the old empty-stub behaviour for routes that don't need it.
-func NewStubsHandlers(builder *models.Builder) *StubsHandlers {
-	return &StubsHandlers{Builder: builder}
+func NewStubsHandlers(builder *models.Builder, repos *repos.Repos) *StubsHandlers {
+	return &StubsHandlers{Builder: builder, Repos: repos}
 }
 
 func (h *StubsHandlers) empty(w http.ResponseWriter, r *http.Request) {
@@ -726,10 +732,18 @@ func (h *StubsHandlers) Locale(w http.ResponseWriter, r *http.Request) {
 }
 
 // Tags handles GET /api/tags. Returns Ollama-compatible model list.
+// When Builder is available, serves real model list from the models registry.
 func (h *StubsHandlers) Tags(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
 	w.Header().Set("Access-Control-Allow-Headers", "*")
+	if h.Builder != nil {
+		list, err := h.Builder.BuildModelsList(r.Context(), models.AllKinds)
+		if err == nil && list != nil {
+			writeJSON(w, http.StatusOK, map[string]any{"models": list})
+			return
+		}
+	}
 	writeJSON(w, http.StatusOK, map[string]any{"models": []any{}})
 }
 
@@ -781,7 +795,22 @@ func (h *StubsHandlers) OIDCCallback(w http.ResponseWriter, r *http.Request) {
 }
 
 // SettingsRequireLogin handles GET /api/settings/require-login.
+// When Repos is available, serves real values from the settings table;
+// otherwise falls back to safe defaults.
 func (h *StubsHandlers) SettingsRequireLogin(w http.ResponseWriter, r *http.Request) {
+	if h.Repos != nil && h.Repos.Settings != nil {
+		settings, err := h.Repos.Settings.Get()
+		if err == nil && settings != nil {
+			writeJSON(w, http.StatusOK, map[string]any{
+				"requireLogin":          settings["requireLogin"],
+				"tunnelDashboardAccess": settings["tunnelDashboardAccess"],
+				"tunnelUrl":             settings["tunnelUrl"],
+				"tailscaleUrl":          settings["tailscaleUrl"],
+			})
+			return
+		}
+	}
+	// Fallback: safe defaults
 	writeJSON(w, http.StatusOK, map[string]any{
 		"requireLogin":          true,
 		"tunnelDashboardAccess": true,
@@ -812,7 +841,15 @@ func (h *StubsHandlers) VersionUpdate(w http.ResponseWriter, r *http.Request) {
 
 // UsageRequestLogs handles GET /api/usage/request-logs. JS handler returns
 // the raw logs object returned by getRecentLogs.
+// When Repos is available, serves recent usage entries from the DB.
 func (h *StubsHandlers) UsageRequestLogs(w http.ResponseWriter, r *http.Request) {
+	if h.Repos != nil && h.Repos.Usage != nil {
+		logs, err := h.Repos.Usage.ListHistory(50)
+		if err == nil && logs != nil {
+			writeJSON(w, http.StatusOK, map[string]any{"logs": logs})
+			return
+		}
+	}
 	writeJSON(w, http.StatusOK, map[string]any{"logs": []any{}})
 }
 
@@ -833,7 +870,21 @@ func (h *StubsHandlers) ProviderNodeDelete(w http.ResponseWriter, r *http.Reques
 }
 
 // ProviderConnectionGet handles GET /api/providers/{id}.
+// When Repos is available, serves real account data from the DB.
 func (h *StubsHandlers) ProviderConnectionGet(w http.ResponseWriter, r *http.Request) {
+	if h.Repos != nil && h.Repos.Accounts != nil {
+		// Extract {id} from URL path
+		path := r.URL.Path
+		parts := strings.Split(path, "/")
+		if len(parts) >= 2 {
+			id := parts[len(parts)-1]
+			account, err := h.Repos.Accounts.GetByID(id)
+			if err == nil && account != nil {
+				writeJSON(w, http.StatusOK, map[string]any{"connection": account})
+				return
+			}
+		}
+	}
 	writeJSON(w, http.StatusNotFound, map[string]any{"error": "Connection not found"})
 }
 

--- a/internal/api/dashboard/stubs_test.go
+++ b/internal/api/dashboard/stubs_test.go
@@ -20,7 +20,7 @@ func (s *stubSource) Snapshot(context.Context) (*models.SourceSnapshot, error) {
 }
 
 func TestModelsList_NilBuilder_ReturnsEmpty(t *testing.T) {
-	h := NewStubsHandlers(nil)
+	h := NewStubsHandlers(nil, nil)
 	req := httptest.NewRequest("GET", "/api/models", nil)
 	rec := httptest.NewRecorder()
 	h.ModelsList(rec, req)
@@ -47,7 +47,7 @@ func TestModelsList_WithBuilder_ReturnsError(t *testing.T) {
 	src := &stubSource{err: context.DeadlineExceeded}
 	builder := models.NewBuilder(nil, src)
 
-	h := NewStubsHandlers(builder)
+	h := NewStubsHandlers(builder, nil)
 	req := httptest.NewRequest("GET", "/api/models", nil)
 	rec := httptest.NewRecorder()
 	h.ModelsList(rec, req)

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -90,7 +90,7 @@ func dashboardRouter(r *repos.Repos, registry *providers.Registry, builder *mode
 	router.With(dashboard.RequireSession).Get("/usage/{connectionId}", usageHandlers.ConnectionUsage)
 	router.With(dashboard.RequireSession).Post("/usage/{connectionId}/codex-reset-credits", usageHandlers.CodexResetCredits)
 
-	stubs := dashboard.NewStubsHandlers(builder)
+	stubs := dashboard.NewStubsHandlers(builder, r)
 
 	proxyPoolHandlers := dashboard.NewProxyPoolHandlers(r.ProxyPools)
 	providerNodeHandlers := dashboard.NewProviderNodeHandlers(r.ProviderNodes)
@@ -305,7 +305,7 @@ func v1Router(r *repos.Repos, builder *models.Builder) http.Handler {
 	messagesHandler := &v1.MessagesHandler{}
 	router.Post("/messages/count_tokens", http.HandlerFunc(messagesHandler.ServeHTTP))
 
-	stubs := dashboard.NewStubsHandlers(builder)
+	stubs := dashboard.NewStubsHandlers(builder, r)
 	router.Post("/audio/transcriptions", stubs.V1AudioTranscriptions)
 	router.Post("/embeddings", stubs.V1Embeddings)
 

--- a/internal/api/routes_test.go
+++ b/internal/api/routes_test.go
@@ -1,0 +1,218 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/9router/9router/internal/db/repos"
+	"github.com/9router/9router/internal/log"
+	"github.com/9router/9router/internal/providers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestRepos creates a Repos with nil DB — sufficient for route existence checks
+// where we don't need actual DB queries, just verify routes are registered.
+func newTestRepos() *repos.Repos {
+	return repos.New(nil)
+}
+
+func TestRoutes_HealthEndpoint(t *testing.T) {
+	logger, _ := log.New("info")
+	r := newTestRepos() // nil DB — health doesn't need it
+	registry := &providers.Registry{}
+
+	router := Routes(logger, r, registry)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestRoutes_VersionEndpoint(t *testing.T) {
+	logger, _ := log.New("info")
+	r := newTestRepos()
+	registry := &providers.Registry{}
+
+	router := Routes(logger, r, registry)
+
+	req := httptest.NewRequest(http.MethodGet, "/version", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Version endpoint may return 200 or 500 depending on build info
+	assert.NotEqual(t, http.StatusNotFound, w.Code)
+}
+
+func TestRoutes_ShutdownEndpoint(t *testing.T) {
+	logger, _ := log.New("info")
+	r := newTestRepos()
+	registry := &providers.Registry{}
+
+	router := Routes(logger, r, registry)
+
+	req := httptest.NewRequest(http.MethodGet, "/shutdown", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Shutdown may return 200 or 500 — just verify it's not 404
+	assert.NotEqual(t, http.StatusNotFound, w.Code)
+}
+
+func TestRoutes_UnknownRouteReturns404(t *testing.T) {
+	logger, _ := log.New("info")
+	r := newTestRepos()
+	registry := &providers.Registry{}
+
+	router := Routes(logger, r, registry)
+
+	req := httptest.NewRequest(http.MethodGet, "/nonexistent", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestRoutes_V1ModelsRequiresAuth(t *testing.T) {
+	logger, _ := log.New("info")
+	r := newTestRepos()
+	registry := &providers.Registry{}
+
+	router := Routes(logger, r, registry)
+
+	// /v1/models without API key should return 401
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.NotEqual(t, http.StatusNotFound, w.Code)
+}
+
+func TestRoutes_DashboardAuthRoutesExist(t *testing.T) {
+	logger, _ := log.New("info")
+	r := newTestRepos()
+	registry := &providers.Registry{}
+
+	router := Routes(logger, r, registry)
+
+	// Auth routes should be accessible without session
+	routes := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, "/api/auth/login"},
+		{http.MethodPost, "/api/auth/logout"},
+		{http.MethodGet, "/api/auth/status"},
+		{http.MethodGet, "/api/auth/check"},
+	}
+
+	for _, route := range routes {
+		t.Run(route.method+" "+route.path, func(t *testing.T) {
+			req := httptest.NewRequest(route.method, route.path, nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			// Should not 404
+			require.NotEqual(t, http.StatusNotFound, w.Code, "%s %s should exist", route.method, route.path)
+		})
+	}
+}
+
+func TestRoutes_DashboardProtectedRoutesRequireSession(t *testing.T) {
+	logger, _ := log.New("info")
+	r := newTestRepos()
+	registry := &providers.Registry{}
+
+	router := Routes(logger, r, registry)
+
+	// These routes require session — should redirect or 401 without session
+	protectedRoutes := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/api/settings"},
+		{http.MethodGet, "/api/providers"},
+		{http.MethodGet, "/api/keys"},
+		{http.MethodGet, "/api/combos"},
+		{http.MethodGet, "/api/usage/history"},
+		{http.MethodGet, "/api/proxy-pools"},
+		{http.MethodGet, "/api/provider-nodes"},
+	}
+
+	for _, route := range protectedRoutes {
+		t.Run(route.method+" "+route.path, func(t *testing.T) {
+			req := httptest.NewRequest(route.method, route.path, nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			// Should return 401/403, not 404
+			assert.NotEqual(t, http.StatusNotFound, w.Code, "%s %s should exist (not 404)", route.method, route.path)
+		})
+	}
+}
+
+func TestRoutes_MiddlewareStackApplied(t *testing.T) {
+	logger, _ := log.New("info")
+	r := newTestRepos()
+	registry := &providers.Registry{}
+
+	router := Routes(logger, r, registry)
+
+	// Verify CORS headers are present (middleware applied)
+	req := httptest.NewRequest(http.MethodOptions, "/health", nil)
+	req.Header.Set("Origin", "http://localhost:3000")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// CORS middleware should handle preflight
+	assert.NotEqual(t, http.StatusNotFound, w.Code)
+}
+
+func TestRoutes_PublicModelsEndpoint(t *testing.T) {
+	logger, _ := log.New("info")
+	r := newTestRepos()
+	registry := &providers.Registry{}
+
+	router := Routes(logger, r, registry)
+
+	// /models is public (no auth required)
+	req := httptest.NewRequest(http.MethodGet, "/models", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Should return 200 (may return empty models list but shouldn't 404)
+	assert.NotEqual(t, http.StatusNotFound, w.Code)
+}
+
+func TestRoutes_StubsRoutesExist(t *testing.T) {
+	logger, _ := log.New("info")
+	r := newTestRepos()
+	registry := &providers.Registry{}
+
+	router := Routes(logger, r, registry)
+
+	// Verify some stub routes are registered (they should return 401 without session, not 404)
+	stubRoutes := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, "/api/settings/proxy-test"},
+		{http.MethodGet, "/api/settings/database"},
+		{http.MethodGet, "/api/pricing"},
+		{http.MethodGet, "/api/translator/load"},
+		{http.MethodPost, "/api/translator/translate"},
+		{http.MethodGet, "/api/cli-tools/all-statuses"},
+		{http.MethodGet, "/api/tunnel/status"},
+		{http.MethodGet, "/api/headroom/status"},
+	}
+
+	for _, route := range stubRoutes {
+		t.Run(route.method+" "+route.path, func(t *testing.T) {
+			req := httptest.NewRequest(route.method, route.path, nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			assert.NotEqual(t, http.StatusNotFound, w.Code, "%s %s should exist as a stub route", route.method, route.path)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Wires real DB-backed data into 4 dashboard stub handlers that previously returned hardcoded empty/static responses.

## Changes

### StubsHandlers enhanced

- **`StubsHandlers` struct** — added optional `Repos *repos.Repos` field
- **`NewStubsHandlers`** — now accepts `(builder, repos)`; pass nil for either to keep old behavior
- **`routes.go`** — updated both call sites to pass `r` (Repos) to `NewStubsHandlers`

### Real handlers wired (4 stubs upgraded)

| Route | Handler | Before | After |
|-------|---------|--------|-------|
| `GET /api/settings/require-login` | `SettingsRequireLogin` | Hardcoded `{requireLogin: true, ...}` | Reads from `SettingsRepo.Get()` — returns real `requireLogin`, `tunnelDashboardAccess`, `tunnelUrl`, `tailscaleUrl` |
| `GET /api/usage/request-logs` | `UsageRequestLogs` | `{logs: []}` | Reads from `UsageRepo.ListHistory(50)` — returns real recent usage entries |
| `GET /api/tags` | `Tags` | `{models: []}` | Uses `Builder.BuildModelsList()` — returns real model list (Ollama-compatible) |
| `GET /api/providers/{id}` | `ProviderConnectionGet` | Always 404 | Reads from `AccountsRepo.GetByID()` — returns real account data |

All handlers gracefully fall back to the old static behavior when `Repos` is nil or DB query fails.

## Testing

```shell
go build ./...   # clean
go test ./internal/api/... -count=1
# ok  github.com/9router/9router/internal/api
# ok  github.com/9router/9router/internal/api/dashboard
```

## Impact

Dashboard now serves real data for settings, usage logs, model tags, and provider connection details — instead of empty stubs. All backward compatible.
