### PR TITLE
feat(dashboard): add KV repo and wire provider/alias CRUD

### DIFF
--- a/internal/api/dashboard/handlers.go
+++ b/internal/api/dashboard/handlers.go
@@ -329,11 +329,12 @@ func (h *ProviderNodeHandlers) Validate(w http.ResponseWriter, r *http.Request) 
 // ProviderHandlers handles provider management
 type ProviderHandlers struct {
 	registry *providers.Registry
+	repos    *repos.Repos
 }
 
 // NewProviderHandlers creates provider handlers
-func NewProviderHandlers(registry *providers.Registry) *ProviderHandlers {
-	return &ProviderHandlers{registry: registry}
+func NewProviderHandlers(registry *providers.Registry, repos *repos.Repos) *ProviderHandlers {
+	return &ProviderHandlers{registry: registry, repos: repos}
 }
 
 // Get returns a provider by ID
@@ -347,14 +348,69 @@ func (h *ProviderHandlers) Get(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"provider": provider})
 }
 
-// Update updates a provider
+// Update updates a provider connection via the accounts repo.
 func (h *ProviderHandlers) Update(w http.ResponseWriter, r *http.Request) {
-	writeError(w, http.StatusNotImplemented, "not_implemented", "Provider update not yet implemented")
+	if h.repos == nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Repos unavailable")
+		return
+	}
+	id := chi.URLParam(r, "id")
+	var updates map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&updates); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_body", err.Error())
+		return
+	}
+
+	account, err := h.repos.Accounts.Update(id, func(acc *repos.Account) {
+		if v, ok := updates["name"]; ok {
+			if s, ok := v.(string); ok {
+				acc.Name = s
+			}
+		}
+		if v, ok := updates["priority"]; ok {
+			if f, ok := v.(float64); ok {
+				acc.Priority = int(f)
+			}
+		}
+		if v, ok := updates["isActive"]; ok {
+			if b, ok := v.(bool); ok {
+				acc.IsActive = b
+			}
+		}
+		if v, ok := updates["providerSpecificData"]; ok {
+			if m, ok := v.(map[string]any); ok {
+				acc.ProviderSpecificData = m
+			}
+		}
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "update_failed", err.Error())
+		return
+	}
+	if account == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Provider not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"success": true, "connection": account})
 }
 
-// Delete removes a provider
+// Delete removes a provider connection from the database.
 func (h *ProviderHandlers) Delete(w http.ResponseWriter, r *http.Request) {
-	writeError(w, http.StatusNotImplemented, "not_implemented", "Provider delete not yet implemented")
+	if h.repos == nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Repos unavailable")
+		return
+	}
+	id := chi.URLParam(r, "id")
+	deleted, err := h.repos.Accounts.Delete(id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "delete_failed", err.Error())
+		return
+	}
+	if !deleted {
+		writeError(w, http.StatusNotFound, "not_found", "Provider not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"success": true, "message": "Connection deleted successfully"})
 }
 
 // GetModels returns models for a provider
@@ -434,19 +490,28 @@ func (h *ProviderHandlers) TestModels(w http.ResponseWriter, r *http.Request) {
 // ModelHandlers handles model management
 type ModelHandlers struct {
 	registry *providers.Registry
+	kv       *repos.KVRepo
 }
 
-// NewModelHandlers creates model handlers
-func NewModelHandlers(registry *providers.Registry) *ModelHandlers {
-	return &ModelHandlers{registry: registry}
+// NewModelHandlers creates model handlers. kv may be nil to disable KV-backed features.
+func NewModelHandlers(registry *providers.Registry, kv *repos.KVRepo) *ModelHandlers {
+	return &ModelHandlers{registry: registry, kv: kv}
 }
 
-// AliasList returns model aliases
+// AliasList returns model aliases from registry and KV store
 func (h *ModelHandlers) AliasList(w http.ResponseWriter, r *http.Request) {
 	aliases := make(map[string]string)
+	// Registry aliases
 	for _, p := range h.registry.Providers {
 		if p.Alias != "" {
 			aliases[p.Alias] = p.ID
+		}
+	}
+	// KV aliases (user-defined)
+	if h.kv != nil {
+		kvAliases, _ := h.kv.GetAll("modelAliases")
+		for k, v := range kvAliases {
+			aliases[k] = v
 		}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"aliases": aliases})
@@ -454,12 +519,45 @@ func (h *ModelHandlers) AliasList(w http.ResponseWriter, r *http.Request) {
 
 // AliasUpdate updates a model alias
 func (h *ModelHandlers) AliasUpdate(w http.ResponseWriter, r *http.Request) {
-	writeError(w, http.StatusNotImplemented, "not_implemented", "Alias update not yet implemented")
+	if h.kv == nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "KV store unavailable")
+		return
+	}
+	var body struct {
+		Alias string `json:"alias"`
+		Model string `json:"model"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_body", err.Error())
+		return
+	}
+	if body.Alias == "" || body.Model == "" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "alias and model required")
+		return
+	}
+	if err := h.kv.Set("modelAliases", body.Alias, body.Model); err != nil {
+		writeError(w, http.StatusInternalServerError, "update_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"success": true, "alias": body.Alias, "model": body.Model})
 }
 
 // AliasDelete removes a model alias
 func (h *ModelHandlers) AliasDelete(w http.ResponseWriter, r *http.Request) {
-	writeError(w, http.StatusNotImplemented, "not_implemented", "Alias delete not yet implemented")
+	if h.kv == nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "KV store unavailable")
+		return
+	}
+	alias := chi.URLParam(r, "alias")
+	if alias == "" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "alias required")
+		return
+	}
+	if err := h.kv.Delete("modelAliases", alias); err != nil {
+		writeError(w, http.StatusInternalServerError, "delete_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"success": true})
 }
 
 // Availability returns model availability

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -115,7 +115,7 @@ func dashboardRouter(r *repos.Repos, registry *providers.Registry, builder *mode
 
 	router.With(dashboard.RequireSession).Get("/models/alias", modelHandlers.AliasList)
 	router.With(dashboard.RequireSession).Put("/models/alias", modelHandlers.AliasUpdate)
-	router.With(dashboard.RequireSession).Delete("/models/alias", modelHandlers.AliasDelete)
+	router.With(dashboard.RequireSession).Delete("/models/alias/{alias}", modelHandlers.AliasDelete)
 	router.With(dashboard.RequireSession).Get("/models/availability", modelHandlers.Availability)
 	router.With(dashboard.RequireSession).Get("/models/custom", modelHandlers.Custom)
 	router.With(dashboard.RequireSession).Get("/models/disabled", modelHandlers.Disabled)
@@ -258,9 +258,9 @@ func dashboardRouter(r *repos.Repos, registry *providers.Registry, builder *mode
 	// NOTE: /provider-nodes/{id} PUT/DELETE already wired to real handlers above.
 
 	// Provider connection stubs.
-	router.With(dashboard.RequireSession).Get("/providers/{id}", stubs.ProviderConnectionGet)
-	router.With(dashboard.RequireSession).Put("/providers/{id}", stubs.ProviderConnectionUpdate)
-	router.With(dashboard.RequireSession).Delete("/providers/{id}", stubs.ProviderConnectionDelete)
+	router.With(dashboard.RequireSession).Get("/providers/{id}", providerHandlers.Get)
+	router.With(dashboard.RequireSession).Put("/providers/{id}", providerHandlers.Update)
+	router.With(dashboard.RequireSession).Delete("/providers/{id}", providerHandlers.Delete)
 	router.With(dashboard.RequireSession).Get("/providers/{id}/models", stubs.ProviderModels)
 	router.With(dashboard.RequireSession).Post("/providers/{id}/test-models", stubs.ProviderTestModels)
 	router.With(dashboard.RequireSession).Get("/providers/suggested-models", stubs.ProviderSuggestedModels)

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -94,8 +94,8 @@ func dashboardRouter(r *repos.Repos, registry *providers.Registry, builder *mode
 
 	proxyPoolHandlers := dashboard.NewProxyPoolHandlers(r.ProxyPools)
 	providerNodeHandlers := dashboard.NewProviderNodeHandlers(r.ProviderNodes)
-	providerHandlers := dashboard.NewProviderHandlers(registry)
-	modelHandlers := dashboard.NewModelHandlers(registry)
+	providerHandlers := dashboard.NewProviderHandlers(registry, r)
+	modelHandlers := dashboard.NewModelHandlers(registry, r.KV)
 
 	router.With(dashboard.RequireSession).Get("/proxy-pools", proxyPoolHandlers.List)
 	router.With(dashboard.RequireSession).Post("/proxy-pools", proxyPoolHandlers.Create)

--- a/internal/db/repos/kv.go
+++ b/internal/db/repos/kv.go
@@ -1,0 +1,103 @@
+package repos
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+)
+
+// KVRepo provides generic key-value access backed by the `kv` table.
+// Each entry is scoped (e.g. "modelAliases", "customModels", "disabledModels").
+//
+// CREATE TABLE kv (scope TEXT, key TEXT, value TEXT, PRIMARY KEY(scope, key));
+type KVRepo struct {
+	db *sql.DB
+}
+
+// NewKVRepo creates a KVRepo backed by db.
+func NewKVRepo(db *sql.DB) *KVRepo {
+	return &KVRepo{db: db}
+}
+
+// GetAll returns all key-value pairs for a scope as a map[string]string.
+func (r *KVRepo) GetAll(scope string) (map[string]string, error) {
+	rows, err := r.db.Query(`SELECT key, value FROM kv WHERE scope = ?`, scope)
+	if err != nil {
+		return nil, fmt.Errorf("kv get all %q: %w", scope, err)
+	}
+	defer rows.Close()
+	result := make(map[string]string)
+	for rows.Next() {
+		var k, v string
+		if err := rows.Scan(&k, &v); err != nil {
+			return nil, fmt.Errorf("kv scan: %w", err)
+		}
+		result[k] = v
+	}
+	return result, rows.Err()
+}
+
+// Get returns the value for a scope+key pair, or "" if not found.
+func (r *KVRepo) Get(scope, key string) (string, bool, error) {
+	var value string
+	err := r.db.QueryRow(`SELECT value FROM kv WHERE scope = ? AND key = ?`, scope, key).Scan(&value)
+	if err == sql.ErrNoRows {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("kv get %q/%q: %w", scope, key, err)
+	}
+	return value, true, nil
+}
+
+// GetJSON returns the value for a scope+key parsed as JSON into target.
+// Returns false if the key doesn't exist.
+func (r *KVRepo) GetJSON(scope, key string, target any) (bool, error) {
+	value, found, err := r.Get(scope, key)
+	if err != nil || !found {
+		return found, err
+	}
+	if err := json.Unmarshal([]byte(value), target); err != nil {
+		return false, fmt.Errorf("kv getJSON %q/%q: %w", scope, key, err)
+	}
+	return true, nil
+}
+
+// Set stores a key-value pair (upsert).
+func (r *KVRepo) Set(scope, key, value string) error {
+	_, err := r.db.Exec(
+		`INSERT INTO kv (scope, key, value) VALUES (?, ?, ?) ON CONFLICT(scope, key) DO UPDATE SET value = excluded.value`,
+		scope, key, value,
+	)
+	if err != nil {
+		return fmt.Errorf("kv set %q/%q: %w", scope, key, err)
+	}
+	return nil
+}
+
+// SetJSON stores a key with a JSON-serialized value.
+func (r *KVRepo) SetJSON(scope, key string, value any) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("kv setJSON marshal %q/%q: %w", scope, key, err)
+	}
+	return r.Set(scope, key, string(data))
+}
+
+// Delete removes a key from a scope.
+func (r *KVRepo) Delete(scope, key string) error {
+	_, err := r.db.Exec(`DELETE FROM kv WHERE scope = ? AND key = ?`, scope, key)
+	if err != nil {
+		return fmt.Errorf("kv delete %q/%q: %w", scope, key, err)
+	}
+	return nil
+}
+
+// DeleteScope removes all keys in a scope.
+func (r *KVRepo) DeleteScope(scope string) error {
+	_, err := r.db.Exec(`DELETE FROM kv WHERE scope = ?`, scope)
+	if err != nil {
+		return fmt.Errorf("kv delete scope %q: %w", scope, err)
+	}
+	return nil
+}

--- a/internal/db/repos/kv_test.go
+++ b/internal/db/repos/kv_test.go
@@ -1,0 +1,86 @@
+package repos
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKVRepo_SetGetDelete(t *testing.T) {
+	db, cleanup := openReposTestDB(t)
+	defer cleanup()
+
+	kv := NewKVRepo(db)
+
+	// Set and get
+	require.NoError(t, kv.Set("test", "key1", "value1"))
+	val, found, err := kv.Get("test", "key1")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "value1", val)
+
+	// Get non-existent
+	_, found, err = kv.Get("test", "nope")
+	require.NoError(t, err)
+	require.False(t, found)
+
+	// Upsert
+	require.NoError(t, kv.Set("test", "key1", "updated"))
+	val, found, err = kv.Get("test", "key1")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "updated", val)
+
+	// Delete
+	require.NoError(t, kv.Delete("test", "key1"))
+	_, found, err = kv.Get("test", "key1")
+	require.NoError(t, err)
+	require.False(t, found)
+}
+
+func TestKVRepo_GetAll(t *testing.T) {
+	db, cleanup := openReposTestDB(t)
+	defer cleanup()
+
+	kv := NewKVRepo(db)
+
+	require.NoError(t, kv.Set("scope1", "a", "1"))
+	require.NoError(t, kv.Set("scope1", "b", "2"))
+	require.NoError(t, kv.Set("scope2", "c", "3"))
+
+	all, err := kv.GetAll("scope1")
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"a": "1", "b": "2"}, all)
+}
+
+func TestKVRepo_DeleteScope(t *testing.T) {
+	db, cleanup := openReposTestDB(t)
+	defer cleanup()
+
+	kv := NewKVRepo(db)
+
+	require.NoError(t, kv.Set("scope1", "a", "1"))
+	require.NoError(t, kv.Set("scope1", "b", "2"))
+
+	require.NoError(t, kv.DeleteScope("scope1"))
+
+	all, err := kv.GetAll("scope1")
+	require.NoError(t, err)
+	require.Empty(t, all)
+}
+
+func TestKVRepo_SetJSONGetJSON(t *testing.T) {
+	db, cleanup := openReposTestDB(t)
+	defer cleanup()
+
+	kv := NewKVRepo(db)
+
+	data := map[string]string{"foo": "bar"}
+	require.NoError(t, kv.SetJSON("test", "json", data))
+
+	var result map[string]string
+	found, err := kv.GetJSON("test", "json", &result)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, data, result)
+}

--- a/internal/db/repos/repos.go
+++ b/internal/db/repos/repos.go
@@ -12,6 +12,7 @@ type Repos struct {
 	Settings      *SettingsRepo
 	ProxyPools    *ProxyPoolRepo
 	ProviderNodes *ProviderNodeRepo
+	KV            *KVRepo
 }
 
 // New creates a Repos instance backed by db.
@@ -24,5 +25,6 @@ func New(db *sql.DB) *Repos {
 		Settings:      NewSettingsRepo(db),
 		ProxyPools:    NewProxyPoolRepo(db),
 		ProviderNodes: NewProviderNodeRepo(db),
+		KV:            NewKVRepo(db),
 	}
 }


### PR DESCRIPTION
## Summary

Add KV store support and wire CRUD operations for provider connections and model aliases.

## Changes

### KV Repo ()
- New  for generic key-value storage using the existing  table
- Methods: , , , , 
- Full test coverage ()

### Repos Integration ()
- Added  field to  struct
- Initialized in  constructor

### Model Handlers ()
- Updated  to accept 
- Implemented : merges registry aliases with KV-stored user aliases
- Implemented : stores alias→model mapping in KV
- Implemented : removes alias from KV

### Provider Handlers ()
- Updated  to accept 
- Implemented : partial update via 
- Implemented : delete via 

### Routes ()
- Updated  - pass repos
- Updated  - pass KV store

## Test Results
- All 31 packages pass (1 pre-existing oauth/services build failure unrelated to this PR)
- KV repo has 4 test cases covering all operations

## Files Changed
-  (new)
-  (new)
- 
- 
- 