### PR TITLE
fix: usage tracking for Antigravity/Gemini streaming responses

### DIFF
--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -127,10 +127,15 @@ export function translateNonStreamingResponse(responseBody, targetFormat, source
 
     if (responseBody.usage) {
       result.usage = {
-        prompt_tokens: responseBody.usage.input_tokens || 0,
-        completion_tokens: responseBody.usage.output_tokens || 0,
-        total_tokens: (responseBody.usage.input_tokens || 0) + (responseBody.usage.output_tokens || 0)
+        prompt_tokens: responseBody.usage.prompt_tokens || responseBody.usage.input_tokens || 0,
+        completion_tokens: responseBody.usage.completion_tokens || responseBody.usage.output_tokens || 0,
+        total_tokens: responseBody.usage.total_tokens || 
+          ((responseBody.usage.prompt_tokens || responseBody.usage.input_tokens || 0) + 
+           (responseBody.usage.completion_tokens || responseBody.usage.output_tokens || 0))
       };
+      if (responseBody.usage.completion_tokens_details) {
+        result.usage.completion_tokens_details = responseBody.usage.completion_tokens_details;
+      }
     }
     return result;
   }

--- a/open-sse/utils/usageTracking.js
+++ b/open-sse/utils/usageTracking.js
@@ -246,11 +246,11 @@ export function extractUsage(chunk) {
     });
   }
 
-  // Claude format (message_delta event)
+  // Claude format (message_delta event) - also handles OpenAI format in final chunk
   if (chunk.type === "message_delta" && chunk.usage && typeof chunk.usage === "object") {
     return normalizeUsage({
-      prompt_tokens: chunk.usage.input_tokens || 0,
-      completion_tokens: chunk.usage.output_tokens || 0,
+      prompt_tokens: chunk.usage.prompt_tokens || chunk.usage.input_tokens || 0,
+      completion_tokens: chunk.usage.completion_tokens || chunk.usage.output_tokens || 0,
       cache_read_input_tokens: chunk.usage.cache_read_input_tokens,
       cache_creation_input_tokens: chunk.usage.cache_creation_input_tokens
     });


### PR DESCRIPTION
## Problem

Dashboard shows `0 / 0` for Antigravity/Gemini requests despite database having correct token data.

**Example:**
```
Input Tokens: 0
Output Tokens: 0
```

But `usageHistory` table has:
```
promptTokens: 422
completionTokens: 266
```

## Root Cause

Two issues in usage extraction logic:

1. **`nonStreamingHandler.js`**: Only checked Anthropic format (`input_tokens`/`output_tokens`), missed OpenAI format (`prompt_tokens`/`completion_tokens`)

2. **`usageTracking.js`**: Claude `message_delta` event handler only checked `input_tokens`/`output_tokens`, but Antigravity streaming final chunk uses OpenAI format

## Fix

### 1. `nonStreamingHandler.js` (lines 127-137)
```javascript
// Before: Anthropic-only
prompt_tokens: responseBody.usage.input_tokens || 0,
completion_tokens: responseBody.usage.output_tokens || 0,

// After: Dual-format support
prompt_tokens: responseBody.usage.prompt_tokens || responseBody.usage.input_tokens || 0,
completion_tokens: responseBody.usage.completion_tokens || responseBody.usage.output_tokens || 0,
```

Also preserves `completion_tokens_details` for reasoning tokens.

### 2. `usageTracking.js` (lines 249-256)
```javascript
// Before: Claude-only
prompt_tokens: chunk.usage.input_tokens || 0,
completion_tokens: chunk.usage.output_tokens || 0,

// After: Fallback to OpenAI format
prompt_tokens: chunk.usage.prompt_tokens || chunk.usage.input_tokens || 0,
completion_tokens: chunk.usage.completion_tokens || chunk.usage.output_tokens || 0,
```

## Testing

Verified against Antigravity streaming responses:
- Final SSE chunk contains `usage` object with `prompt_tokens`/`completion_tokens`
- Dashboard now correctly displays token counts
- Database saves correct values

## Files Changed

- `open-sse/handlers/chatCore/nonStreamingHandler.js` (5 insertions, 3 deletions)
- `open-sse/utils/usageTracking.js` (3 insertions, 3 deletions)