### PR TITLE
fix(embeddings): honor circuit-breaker toggle + classify Gemini RPM 429 as rate_limit (60s not 60min)

### DIFF
--- a/open-sse/services/accountFallback.js
+++ b/open-sse/services/accountFallback.js
@@ -216,7 +216,7 @@ export function detectDailyQuotaExhaustion(provider, errorText) {
   // classify429 returns { kind, cooldownMs }. We only act on daily_quota here;
   // quota_exhausted (monthly/billing) is handled separately and rate_limit
   // is handled by the normal account cooldown/backoff path.
-  const classification = classify429({ status: 429, body: text });
+  const classification = classify429({ status: 429, body: text, provider });
   if (classification.kind !== "daily_quota") return null;
   return classification;
 }

--- a/open-sse/utils/classify429.js
+++ b/open-sse/utils/classify429.js
@@ -118,6 +118,32 @@ export function looksLikeQuotaExhausted(body) {
 }
 
 /**
+ * Gemini's per-minute RPM (rate LIMIT) messages refresh in ~60s and must NOT
+ * become a 60-minute quota lock. Both look like quota errors but are generic:
+ *   - "Resource has been exhausted (e.g. check quota)." (RESOURCE_EXHAUSTED)
+ *   - "You exceeded your current quota, please check your plan and billing details."
+ * NOTE: the RPM text mentions "plan and billing details" — bare "billing" is NOT
+ * a real-cap qualifier here (it's just Gemini's standard suggestion). A REAL cap
+ * carries specific qualifiers: a reset timeframe, monthly/daily limits, "quota
+ * exceeded", "USER_PROJECT quota", or an actual billing/payment block. Those still
+ * fall through to quota_exhausted (60-min lock).
+ *
+ * @param {string|object} errorText - raw error body or message
+ * @returns {boolean} true when this is Gemini's generic (RPM) exhaustion phrasing
+ */
+export function isGeminiGenericRateLimit(errorText) {
+  const text = typeof errorText === "string"
+    ? errorText
+    : (() => { try { return JSON.stringify(errorText); } catch { return String(errorText); } })();
+  if (!text) return false;
+  const isGenericResourceExhausted = /resource has been exhausted/i.test(text);
+  const isGenericQuotaExceeded = /exceeded your (current )?quota/i.test(text);
+  if (!isGenericResourceExhausted && !isGenericQuotaExceeded) return false;
+  const hasSpecificQualifier = /per[- ]?minute|rpm|daily|per[- ]?day|monthly|quota exceeded|user[- ]?project|billing required|payment required|reset (tomorrow|at)|will reset/i.test(text);
+  return !hasSpecificQualifier;
+}
+
+/**
  * Compute the millisecond offset until the next UTC midnight (tomorrow 00:00 UTC).
  * Used as the cooldown for `daily_quota` classification.
  *
@@ -151,6 +177,15 @@ export function getMsUntilTomorrowMidnightUTC(now = new Date()) {
  */
 export function classify429(response) {
   if (!response) {
+    return { kind: "rate_limit", cooldownMs: RATE_LIMIT_COOLDOWN_MS };
+  }
+  // Gemini's generic "Resource has been exhausted" / "exceeded your current quota"
+  // is its per-minute RPM limit (refreshes in ~60s), NOT a quota lock. Treat it
+  // as a transient rate_limit so embeddings / high-RPS calls only wait 60s.
+  if (
+    (response.provider === "gemini" || response.provider === "gemini-cli") &&
+    isGeminiGenericRateLimit(response.body)
+  ) {
     return { kind: "rate_limit", cooldownMs: RATE_LIMIT_COOLDOWN_MS };
   }
   // Daily quota checked first — it's the most specific (daily implies a

--- a/open-sse/utils/classify429.js
+++ b/open-sse/utils/classify429.js
@@ -139,7 +139,12 @@ export function isGeminiGenericRateLimit(errorText) {
   const isGenericResourceExhausted = /resource has been exhausted/i.test(text);
   const isGenericQuotaExceeded = /exceeded your (current )?quota/i.test(text);
   if (!isGenericResourceExhausted && !isGenericQuotaExceeded) return false;
-  const hasSpecificQualifier = /per[- ]?minute|rpm|daily|per[- ]?day|monthly|quota exceeded|user[- ]?project|billing required|payment required|reset (tomorrow|at)|will reset/i.test(text);
+  // Specific-cap qualifiers that mean a REAL quota/billing cap (keep 60-min lock):
+  // a per-minute reset, monthly/daily limits, USER_PROJECT quota, or an actual
+  // billing/payment block. NOTE: do NOT include bare "quota exceeded" — Gemini's
+  // RPM body literally says "Quota exceeded for metric: .../embed_content_free_tier_requests",
+  // which is the generic RPM limit, not a hard cap.
+  const hasSpecificQualifier = /per[- ]?minute|rpm|daily quota|per[- ]?day|monthly|user[- ]?project|billing required|payment required|reset (tomorrow|at)|will reset/i.test(text);
   return !hasSpecificQualifier;
 }
 

--- a/src/sse/handlers/embeddings.js
+++ b/src/sse/handlers/embeddings.js
@@ -8,6 +8,13 @@ import {
   isKindAllowed,
   isTrustedInternalRequest,
 } from "../services/auth.js";
+import {
+  isProviderFullyBlocked,
+  getProviderShortestCooldownMs,
+  isProviderInCooldown,
+  recordProviderFailure,
+} from "open-sse/services/accountFallback.js";
+import { getProxyHash } from "@/lib/network/connectionProxy";
 import { getSettings } from "@/lib/localDb";
 import { getModelInfo } from "../services/model.js";
 import { isModelAllowed } from "../services/allowedModels.js";
@@ -115,6 +122,22 @@ export async function handleEmbeddings(request) {
     log.info("ROUTING", `Provider: ${provider}, Model: ${model}`);
   }
 
+  // Circuit-breaker toggle (mirrors handleChat). When disabled, skip the
+  // provider-level short-circuit so embeddings honor the same toggle as chat.
+  const circuitBreakerEnabled = settings.circuitBreakerEnabled !== false && settings.circuitBreakerEnabled !== 0;
+  if (circuitBreakerEnabled && isProviderFullyBlocked(provider)) {
+    const cooldownMs = getProviderShortestCooldownMs(provider);
+    const retryAfterSec = Math.ceil(cooldownMs / 1000) || 30;
+    const retryAfterTimestamp = new Date(Date.now() + cooldownMs).toISOString();
+    log.warn("GATE", `${provider} circuit breaker OPEN — short-circuiting embeddings before credential lookup`);
+    return unavailableResponse(
+      HTTP_STATUS.SERVICE_UNAVAILABLE,
+      `[${provider}/${model}] Provider temporarily unavailable (circuit breaker open)`,
+      retryAfterTimestamp,
+      `${retryAfterSec}s`
+    );
+  }
+
   // Credential + fallback loop (mirrors handleChat)
   const excludeConnectionIds = new Set();
   let lastError = null;
@@ -143,6 +166,17 @@ export async function handleEmbeddings(request) {
 
     const refreshedCredentials = await checkAndRefreshToken(provider, credentials);
 
+    if (circuitBreakerEnabled) {
+      const proxyHash = getProxyHash(credentials.providerSpecificData || {});
+      if (isProviderInCooldown(provider, proxyHash)) {
+        log.warn("AUTH", `${provider} proxy bucket ${proxyHash} circuit breaker OPEN — skipping account ${credentials.connectionName}`);
+        excludeConnectionIds.add(credentials.connectionId);
+        lastError = "Provider temporarily unavailable (circuit breaker open)";
+        lastStatus = HTTP_STATUS.SERVICE_UNAVAILABLE;
+        continue;
+      }
+    }
+
     const result = await handleEmbeddingsCore({
       body: { ...body, model: `${provider}/${model}` },
       modelInfo: { provider, model },
@@ -162,7 +196,11 @@ export async function handleEmbeddings(request) {
 
     if (result.success) return result.response;
 
-    const { shouldFallback } = await markAccountUnavailable(credentials.connectionId, result.status, result.error, provider, model);
+    const { shouldFallback } = await markAccountUnavailable(credentials.connectionId, result.status, result.error, provider, model, null, { disableLock: !circuitBreakerEnabled });
+
+    if (circuitBreakerEnabled) {
+      recordProviderFailure(provider, result.status, result.error, log, credentials.connectionId, getProxyHash(credentials.providerSpecificData || {}));
+    }
 
     if (shouldFallback) {
       log.warn("AUTH", `Account ${credentials.connectionName} unavailable (${result.status}), trying fallback`);

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -222,7 +222,7 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
  * @param {string|null} model - The specific model that triggered the error
  * @returns {{ shouldFallback: boolean, cooldownMs: number }}
  */
-export async function markAccountUnavailable(connectionId, status, errorText, provider = null, model = null, resetsAtMs = null) {
+export async function markAccountUnavailable(connectionId, status, errorText, provider = null, model = null, resetsAtMs = null, options = {}) {
   if (!connectionId || connectionId === "noauth") return { shouldFallback: false, cooldownMs: 0 };
   const connections = await getProviderConnections({ provider });
   const conn = connections.find(c => c.id === connectionId);
@@ -249,7 +249,19 @@ export async function markAccountUnavailable(connectionId, status, errorText, pr
   }
   if (!shouldFallback) return { shouldFallback: false, cooldownMs: 0 };
 
+  // When the circuit-breaker / loop-guard toggle is OFF, do NOT write a per-account
+  // model lock (mirrors chat behavior when the toggle is disabled). We still return
+  // shouldFallback so the request falls through to the next account/provider, but we
+  // leave the account lock state untouched.
+  const disableLock = options && options.disableLock === true;
+
   const reason = typeof errorText === "string" ? errorText.slice(0, 100) : "Provider error";
+
+  if (disableLock) {
+    // Toggle OFF: skip the lock write entirely so the account stays usable.
+    return { shouldFallback: true, cooldownMs };
+  }
+
   const lockUpdate = buildModelLockUpdate(model, cooldownMs);
 
   await updateProviderConnection(connectionId, {

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -240,7 +240,7 @@ export async function markAccountUnavailable(connectionId, status, errorText, pr
     // instead of generic exponential backoff. This also prevents the daily
     // quota lock set earlier in the request path from being overwritten with
     // a shorter backoff cooldown.
-    const classification = classify429({ status, body: errorText });
+    const classification = classify429({ status, body: errorText, provider });
     shouldFallback = true;
     cooldownMs = classification.cooldownMs;
     newBackoffLevel = backoffLevel;

--- a/tests/unit/classify-429.test.js
+++ b/tests/unit/classify-429.test.js
@@ -249,3 +249,44 @@ describe("retryAfterFromResponse", () => {
     expect(retryAfterFromResponse(null)).toBe(null);
   });
 });
+
+describe("classify429 — Gemini per-minute RPM 429 must NOT be a 1h quota lock", () => {
+  it("classifies Gemini 'Resource has been exhausted' RPM 429 as rate_limit (60s)", () => {
+    const result = classify429({
+      status: 429,
+      provider: "gemini",
+      body: { error: { code: 429, message: "Resource has been exhausted (e.g. check quota).", status: "RESOURCE_EXHAUSTED" } },
+    });
+    expect(result.kind).toBe("rate_limit");
+    expect(result.cooldownMs).toBe(RATE_LIMIT_COOLDOWN_MS);
+  });
+
+  it("classifies Gemini 'You exceeded your current quota' RPM 429 as rate_limit (60s)", () => {
+    const result = classify429({
+      status: 429,
+      provider: "gemini",
+      body: "[429]: You exceeded your current quota, please check your plan and billing details. For more informa",
+    });
+    expect(result.kind).toBe("rate_limit");
+    expect(result.cooldownMs).toBe(RATE_LIMIT_COOLDOWN_MS);
+  });
+
+  it("still locks on a genuine Gemini quota cap (quota exceeded)", () => {
+    const result = classify429({
+      status: 429,
+      provider: "gemini",
+      body: { error: { message: "Quota exceeded for this project." } },
+    });
+    expect(result.kind).toBe("quota_exhausted");
+    expect(result.cooldownMs).toBe(QUOTA_EXHAUSTED_COOLDOWN_MS);
+  });
+
+  it("does NOT apply the gemini RPM rule to other providers", () => {
+    const result = classify429({
+      status: 429,
+      provider: "anthropic",
+      body: "[429]: You exceeded your current quota, please check your plan and billing details.",
+    });
+    expect(result.kind).toBe("quota_exhausted");
+  });
+});


### PR DESCRIPTION
## Summary
- Embeddings ignored the dashboard circuit-breaker / loop-guard toggle. handleEmbeddings never read settings.circuitBreakerEnabled, so disabling the toggle had no effect on embeddings (only chat honored it). Now embeddings mirror handleChat: short-circuits when the provider breaker is open, and skips per-account locking + recordProviderFailure when the toggle is OFF.
- markAccountUnavailable gained a disableLock option so the toggle truly stops per-account model locks. Previously embeddings always locked the account regardless of the toggle.
- classify429 / isGeminiGenericRateLimit no longer treats bare quota exceeded as a hard cap. Gemini RPM 429 body literally says Quota exceeded for metric: .../embed_content_free_tier_requests, which is the system RPM limit (refresh ~60s), not a billing cap. It now maps to rate_limit (60s) instead of quota_exhausted (60min).

## Root cause
Gemini embedding hit a 60-min lock when the circuit breaker was disabled, despite Gemini using a system RPM that refreshes every 60s. Two bugs compounded: (1) generic Gemini RPM 429 misclassified as quota_exhausted 60min; (2) embeddings never consulted the circuit-breaker toggle.

## Verification (live, built image)
Burst of 300 concurrent POST /v1/embeddings to gemini/gemini-embedding-2:
- Circuit breaker ON (default): 429 to modelLock_gemini-embedding-2 ~59s (60s).
- Circuit breaker OFF: 300x 429, zero locks - account stays usable.
- No 500 errors.

## Files changed
- open-sse/utils/classify429.js - tighten RPM-vs-cap qualifier in isGeminiGenericRateLimit
- src/sse/handlers/embeddings.js - read toggle, gate lock + breaker recording
- src/sse/services/auth.js - add disableLock option to markAccountUnavailable