### PR TITLE
feat(antigravity): add Gemini 3.6 Flash tiers via daily Cloud Code host

### DIFF
--- a/cli/src/cli/menus/providers.js
+++ b/cli/src/cli/menus/providers.js
@@ -53,6 +53,9 @@ const PROVIDER_MODELS = {
     { id: "glm-4.7" },
   ],
   ag: [
+    { id: "gemini-3.6-flash-high" },
+    { id: "gemini-3.6-flash-medium" },
+    { id: "gemini-3.6-flash-low" },
     { id: "gemini-3-flash-agent" },
     { id: "gemini-3.5-flash-low" },
     { id: "gemini-3.5-flash-extra-low" },

--- a/open-sse/config/antigravityModelAliases.js
+++ b/open-sse/config/antigravityModelAliases.js
@@ -27,6 +27,33 @@ export const ANTIGRAVITY_PUBLIC_MODELS = Object.freeze([
     toolCalling: true,
   },
   {
+    id: "gemini-3.6-flash-high",
+    name: "Gemini 3.6 Flash (High)",
+    contextLength: 1048576,
+    maxOutputTokens: 65536,
+    supportsReasoning: true,
+    supportsVision: true,
+    toolCalling: true,
+  },
+  {
+    id: "gemini-3.6-flash-medium",
+    name: "Gemini 3.6 Flash (Medium)",
+    contextLength: 1048576,
+    maxOutputTokens: 65536,
+    supportsReasoning: true,
+    supportsVision: true,
+    toolCalling: true,
+  },
+  {
+    id: "gemini-3.6-flash-low",
+    name: "Gemini 3.6 Flash (Low)",
+    contextLength: 1048576,
+    maxOutputTokens: 65536,
+    supportsReasoning: true,
+    supportsVision: true,
+    toolCalling: true,
+  },
+  {
     id: "gemini-3.5-flash-low",
     name: "Gemini 3.5 Flash (Low)",
     contextLength: 1048576,
@@ -143,6 +170,8 @@ export const ANTIGRAVITY_PUBLIC_MODELS = Object.freeze([
 ]);
 
 export const ANTIGRAVITY_MODEL_ALIASES = Object.freeze({
+  "gemini-3.6-flash": "gemini-3.6-flash-medium",
+  "gemini-3.6-flash-preview": "gemini-3.6-flash-high",
   "gemini-3.5-flash-low": "gemini-3.5-flash-extra-low",
   "gemini-3.5-flash-medium": "gemini-3.5-flash-low",
   "gemini-3.5-flash-high": "gemini-3-flash-agent",

--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -128,6 +128,13 @@ export class AntigravityExecutor extends BaseExecutor {
     return `${baseUrl}/v1internal:${action}`;
   }
 
+  // Daily host has newer models (Gemini 3.6). Production returns 404 for those IDs.
+  // Rotate to the next baseUrl on 404 as well as rate-limit.
+  shouldRetry(status, urlIndex) {
+    const retriable = status === HTTP_STATUS.RATE_LIMITED || status === HTTP_STATUS.NOT_FOUND || status === 404;
+    return retriable && urlIndex + 1 < this.getFallbackCount();
+  }
+
   // sessionId comes from transformRequest output; base.execute runs transformRequest before
   // buildHeaders, so we read it from instance state cached there (fallback: explicit arg).
   buildHeaders(credentials, stream = true, sessionId = null) {

--- a/open-sse/providers/registry/antigravity.js
+++ b/open-sse/providers/registry/antigravity.js
@@ -19,7 +19,12 @@ export default {
   category: "oauth",
   serviceKinds: ["llm", "image"],
   transport: {
-    baseUrls: [ANTIGRAVITY_IDE_BASE_URL],
+    // Gemini 3.6 Flash is only served from the daily Cloud Code host today.
+    // Keep production as fallback for older models if daily flakes.
+    baseUrls: [
+      "https://daily-cloudcode-pa.googleapis.com",
+      ANTIGRAVITY_IDE_BASE_URL,
+    ],
     format: "antigravity",
     headers: {
       "User-Agent": ANTIGRAVITY_IDE_USER_AGENT,
@@ -36,7 +41,7 @@ export default {
       },
     },
     usage: {
-      quotaApiUrl: "https://cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
+      quotaApiUrl: "https://daily-cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
       loadProjectApiUrl: "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist",
       tokenUrl: "https://oauth2.googleapis.com/token",
     },
@@ -44,6 +49,9 @@ export default {
     clientSecret: "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",
   },
   models: [
+    { id: "gemini-3.6-flash-high", name: "Gemini 3.6 Flash (High)" },
+    { id: "gemini-3.6-flash-medium", name: "Gemini 3.6 Flash (Medium)" },
+    { id: "gemini-3.6-flash-low", name: "Gemini 3.6 Flash (Low)" },
     { id: "gemini-3-flash-agent", name: "Gemini 3.5 Flash (High)" },
     { id: "gemini-3.5-flash-low", name: "Gemini 3.5 Flash (Medium)" },
     { id: "gemini-3.5-flash-extra-low", name: "Gemini 3.5 Flash (Low)" },

--- a/src/shared/constants/cliTools.js
+++ b/src/shared/constants/cliTools.js
@@ -8,8 +8,11 @@ export const MITM_TOOLS = {
     description: "Google Antigravity IDE with MITM",
     configType: "mitm",
     mitmDomain: "daily-cloudcode-pa.googleapis.com",
-    modelAliases: ["gemini-3.5-flash-low", "gemini-3-flash-agent", "gemini-3.5-flash-extra-low", "gemini-3.1-pro-low", "gemini-pro-agent", "claude-sonnet-4-6", "claude-opus-4-6-thinking", "gpt-oss-120b-medium", "gemini-3-flash"],
+    modelAliases: ["gemini-3.6-flash-high", "gemini-3.6-flash-medium", "gemini-3.6-flash-low", "gemini-3.5-flash-low", "gemini-3-flash-agent", "gemini-3.5-flash-extra-low", "gemini-3.1-pro-low", "gemini-pro-agent", "claude-sonnet-4-6", "claude-opus-4-6-thinking", "gpt-oss-120b-medium", "gemini-3-flash"],
     defaultModels: [
+      { id: "gemini-3.6-flash-high", name: "Gemini 3.6 Flash (High)", alias: "gemini-3.6-flash-high" },
+      { id: "gemini-3.6-flash-medium", name: "Gemini 3.6 Flash (Medium)", alias: "gemini-3.6-flash-medium" },
+      { id: "gemini-3.6-flash-low", name: "Gemini 3.6 Flash (Low)", alias: "gemini-3.6-flash-low" },
       { id: "gemini-3.5-flash-low", name: "Gemini 3.5 Flash (Medium) / Default", alias: "gemini-3.5-flash-low", mandatory: true },
       { id: "gemini-3-flash-agent", name: "Gemini 3.5 Flash (High)", alias: "gemini-3-flash-agent" },
       { id: "gemini-3.5-flash-extra-low", name: "Gemini 3.5 Flash (Low)", alias: "gemini-3.5-flash-extra-low" },


### PR DESCRIPTION
## Summary
- Add Gemini 3.6 Flash High/Medium/Low to the Antigravity provider registry, public model aliases, CLI menu, and MITM tool model list.
- Prefer `daily-cloudcode-pa.googleapis.com` for Antigravity traffic because Gemini 3.6 is only available there today; keep production `cloudcode-pa.googleapis.com` as fallback.
- Rotate to the next Antigravity base URL on HTTP 404 (as well as 429) so older models still recover if daily is down.

## Context
Antigravity's IDE model picker already exposes Gemini 3.6 Flash (High/Medium/Low). Live `fetchAvailableModels` on the daily Cloud Code host returns:

- `gemini-3.6-flash-high`
- `gemini-3.6-flash-medium`
- `gemini-3.6-flash-low`
- `gemini-3.6-flash-tiered` (internal/tiered; not exposed as a user model)

Production `cloudcode-pa.googleapis.com` still returns 404 for those model IDs. Without this change, VansRouter cannot surface or route the new models.

## Changes
| File | Change |
|---|---|
| `open-sse/providers/registry/antigravity.js` | Register 3.6 models; daily-first `baseUrls`; daily quota discovery URL |
| `open-sse/config/antigravityModelAliases.js` | Public models + friendly aliases (`gemini-3.6-flash` → medium) |
| `open-sse/executors/antigravity.js` | `shouldRetry` also rotates on 404 |
| `cli/src/cli/menus/providers.js` | CLI model list |
| `src/shared/constants/cliTools.js` | MITM Antigravity model aliases/default models |

## Test plan
- [x] `fetchAvailableModels` on daily host lists Gemini 3.6 tiers
- [x] Direct `generateContent` to daily host succeeds for high/medium/low; production returns 404
- [x] Built image exposes `ag/gemini-3.6-flash-high|medium|low` on `/v1/models`
- [x] Live `/v1/chat/completions` for all three tiers returns content
- [x] Existing Antigravity models (3.5 Flash / 3.1 Pro / Claude) still route successfully

## Notes
- Diff is intentionally small (+53 / -3). No schema migration.
- `gemini-3.6-flash-tiered` is intentionally not exposed as a public model id (no display name / thinking budget -1).