### PR TITLE
fix(classify429): treat Grok CLI free-usage-exhausted as daily_quota

### DIFF
--- a/open-sse/utils/classify429.js
+++ b/open-sse/utils/classify429.js
@@ -50,6 +50,11 @@ const DAILY_QUOTA_PATTERNS = [
   /reset.*tomorrow/i,
   /try again tomorrow/i,
   /come back tomorrow/i,
+  // Grok CLI free-tier daily usage (subscription:free-usage-exhausted)
+  // Resets at 00:00 UTC — treat as daily_quota, not a 60s rate_limit.
+  /free.?usage.?exhaust/i,
+  /used all.*free usage/i,
+  /subscription.*free.*usage.*exhaust/i,
 ];
 
 /**

--- a/tests/unit/classify-429.test.js
+++ b/tests/unit/classify-429.test.js
@@ -115,6 +115,39 @@ describe("classify429 — daily_quota", () => {
   });
 });
 
+describe("classify429 — Grok CLI free-usage-exhausted is daily_quota (00:00 UTC)", () => {
+  it("classifies subscription:free-usage-exhausted JSON as daily_quota", () => {
+    const body = {
+      code: "subscription:free-usage-exhausted",
+      error: "You've used all the included free usage",
+    };
+    const result = classify429({ status: 429, body, provider: "grok-cli" });
+    expect(result.kind).toBe("daily_quota");
+    expect(result.cooldownMs).toBeGreaterThan(0);
+    expect(result.cooldownMs).toBeLessThanOrEqual(24 * 60 * 60 * 1000);
+  });
+
+  it("classifies 'You've used all the included free usage' as daily_quota", () => {
+    const result = classify429({
+      status: 429,
+      body: "You've used all the included free usage",
+      provider: "grok-cli",
+    });
+    expect(result.kind).toBe("daily_quota");
+  });
+
+  it("classifies 'free usage exhausted' as daily_quota", () => {
+    const result = classify429({ status: 429, body: "free usage exhausted", provider: "grok-cli" });
+    expect(result.kind).toBe("daily_quota");
+  });
+
+  it("does not treat plain rate-limit text as daily_quota", () => {
+    const result = classify429({ status: 429, body: "rate limit exceeded", provider: "grok-cli" });
+    expect(result.kind).toBe("rate_limit");
+    expect(result.cooldownMs).toBe(RATE_LIMIT_COOLDOWN_MS);
+  });
+});
+
 describe("classify429 — daily_quota takes priority over quota_exhausted", () => {
   it("classifies 'daily quota exceeded' as daily_quota (not quota_exhausted)", () => {
     // "exceed.*quota" would match quota_exhausted, but "daily" prefix makes it daily_quota

--- a/tests/unit/daily-quota-detection.test.js
+++ b/tests/unit/daily-quota-detection.test.js
@@ -30,6 +30,14 @@ describe("detectDailyQuotaExhaustion", () => {
     expect(result?.kind).toBe("daily_quota");
   });
 
+  it("returns daily_quota for Grok CLI subscription:free-usage-exhausted", () => {
+    const result = detectDailyQuotaExhaustion(
+      "grok-cli",
+      { code: "subscription:free-usage-exhausted", error: "You've used all the included free usage" },
+    );
+    expect(result?.kind).toBe("daily_quota");
+  });
+
   it("returns daily_quota for nested JSON body with daily quota message", () => {
     const result = detectDailyQuotaExhaustion("openai", { error: { message: "daily quota used up" } });
     expect(result?.kind).toBe("daily_quota");


### PR DESCRIPTION
## Summary
Grok CLI free-tier accounts that hit `subscription:free-usage-exhausted` were only locked for **60s** (`rate_limit`), so VansRouter kept retrying them every minute until midnight. That quota actually resets at **00:00 UTC**, so it should be classified as `daily_quota`.

## Problem
`cli-chat-proxy.grok.com` returns:
```json
{"code":"subscription:free-usage-exhausted","error":"You've used all the included free usage"}
```
None of the existing `DAILY_QUOTA_PATTERNS` / `QUOTA_EXHAUSTED_PATTERNS` matched, so `classify429` fell through to:
```js
{ kind: "rate_limit", cooldownMs: 60_000 }
```
`markAccountUnavailable` then wrote a 60s `modelLock_*`, and the account was selected again after a minute — still exhausted.

## Fix
Add three patterns to `DAILY_QUOTA_PATTERNS` in `open-sse/utils/classify429.js`:
- `/free.?usage.?exhaust/i`
- `/used all.*free usage/i`
- `/subscription.*free.*usage.*exhaust/i`

Cooldown path is unchanged: `daily_quota` → cooldown until next **00:00 UTC** via `getMsUntilTomorrowMidnightUTC()`.

## Tests
- `tests/unit/classify-429.test.js` — Grok free-usage cases + regression that plain rate-limit text still maps to `rate_limit`
- `tests/unit/daily-quota-detection.test.js` — `detectDailyQuotaExhaustion("grok-cli", …)` returns `daily_quota`

```
✓ unit/classify-429.test.js (49 tests)
✓ unit/daily-quota-detection.test.js (17 tests)
Test Files  2 passed (2)
     Tests  66 passed (66)
```

## Verified live
Against a production-shaped 429 body:
| body | before | after |
|---|---|---|
| `subscription:free-usage-exhausted` / "You've used all the included free usage" | `rate_limit` 60s | `daily_quota` → 00:00 UTC |
| "rate limit exceeded" | `rate_limit` 60s | unchanged |
| Gemini "Resource has been exhausted" | `rate_limit` 60s | unchanged |

## Impact
- Only accounts whose 429 body matches the new free-usage phrasing get a longer lock
- Other providers / plain 429s are unaffected
