### PR TITLE
fix(usage): unwrap Antigravity response envelope in extractUsageFromResponse

### DIFF
--- a/open-sse/handlers/chatCore/requestDetail.js
+++ b/open-sse/handlers/chatCore/requestDetail.js
@@ -44,13 +44,31 @@ export function extractUsageFromResponse(responseBody) {
     };
   }
 
-  // Gemini format
-  if (responseBody.usageMetadata) {
+  // Gemini / Antigravity format
+  // Antigravity wraps usageMetadata inside response:
+  //   { response: { candidates: [...], usageMetadata: {...} } }
+  // Without the unwrap, non-stream Antigravity requests land as 0/0 in
+  // requestDetails (and disappear from Recent Requests which filters
+  // zero-token rows). Streaming path already unwraps this in
+  // usageTracking.js; non-stream route uses a different function.
+  const usageMeta = responseBody.usageMetadata || responseBody.response?.usageMetadata;
+  if (usageMeta && typeof usageMeta === "object") {
+    const thoughts = usageMeta.thoughtsTokenCount || 0;
+    const candidates = usageMeta.candidatesTokenCount || 0;
+    // Derive candidates from total when upstream omits it
+    let completion = candidates;
+    const total = usageMeta.totalTokenCount || 0;
+    const prompt = usageMeta.promptTokenCount || 0;
+    if (completion === 0 && total > 0) {
+      completion = Math.max(0, total - prompt - thoughts);
+    }
     return {
-      prompt_tokens: responseBody.usageMetadata.promptTokenCount || 0,
-      completion_tokens: responseBody.usageMetadata.candidatesTokenCount || 0,
-      cached_tokens: responseBody.usageMetadata.cachedContentTokenCount || 0,
-      reasoning_tokens: responseBody.usageMetadata.thoughtsTokenCount || 0
+      prompt_tokens: prompt,
+      // Fold thoughts into completion so saveUsageStats (which only reads
+      // prompt/completion) doesn't drop reasoning-heavy AG responses as 0 out.
+      completion_tokens: completion + thoughts,
+      cached_tokens: usageMeta.cachedContentTokenCount || 0,
+      reasoning_tokens: thoughts
     };
   }
 


### PR DESCRIPTION
## Problem

Non-stream requests to Antigravity (e.g. `ag/gemini-3.1-pro-low`) were always recorded with 0/0 tokens in `requestDetails`, making them invisible in the Recent Requests overview panel (which filters zero-token rows).

**Root cause:** `extractUsageFromResponse()` in the non-stream path only checked `responseBody.usageMetadata` (top-level Gemini format), but Antigravity wraps `usageMetadata` inside `response.usageMetadata`:

```json
{
  "response": {
    "candidates": [...],
    "usageMetadata": { ... }
  }
}
```

The streaming path already handles this correctly via `usageTracking.js` (line 286: `chunk.usageMetadata || chunk.response?.usageMetadata`), but the non-stream path in `requestDetail.js` had its own standalone extractor that missed the envelope.

## Fix

- Unwrap `response.usageMetadata` with `responseBody.usageMetadata || responseBody.response?.usageMetadata`
- Derive `candidatesTokenCount` from `totalTokenCount` when upstream omits it (same fallback as streaming path)
- Fold `thoughtsTokenCount` into `completion_tokens` so reasoning-heavy responses aren't dropped by `saveUsageStats`

## Verification

**Before:** 34/35 Antigravity non-stream requests in DB showed `0/0` tokens.  
**After:** Same request shows `191` completion tokens (with reasoning folded in).