### PR TITLE
fix(antigravity): strip parametersJsonSchema before sending to v1internal

### DIFF
--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -245,6 +245,9 @@ export class AntigravityExecutor extends BaseExecutor {
               ? cleanJSONSchemaForAntigravity(structuredClone(fn.parameters))
               : { type: "object", properties: { reason: { type: "string", description: "Brief explanation" } }, required: ["reason"] }
           });
+          // Strip parametersJsonSchema — v1internal uses parameters only;
+          // both fields cause 400 "must not be set when parameters is set".
+          delete allDeclarations[allDeclarations.length - 1].parametersJsonSchema;
         }
       }
       tools = allDeclarations.length > 0 ? [{ functionDeclarations: allDeclarations }] : [];


### PR DESCRIPTION
## Problem

After merging PR #61 (Gemini CLI tool schema fix), sending requests through Antigravity via `v1internal` fails with:

> `parameters_json_schema must not be set when parameters is set.`

All 82 tool declarations are rejected by Google's API.

## Root Cause

PR #61 correctly converts tool schemas from `parameters` → `parametersJsonSchema` for Cloud Code Assist, which requires the latter. However, `AntigravityExecutor.transformRequest()` spreads the incoming function declarations (`...fn`) and then sets `parameters` — resulting in both fields present on the same declaration. The Antigravity `v1internal` API rejects this combination.

## Fix

Strip `parametersJsonSchema` after building each function declaration in the antigravity executor tool pipeline. The `v1internal` endpoint uses the standard `parameters` field.

## Impact

Zero — this is purely a compatibility fix. No features, schemas, or provider support is affected.