### PR TITLE
feat: proxy rotation + custom pool selection, API key quota tracker, Tailscale fix

### DIFF
--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
@@ -4,17 +4,13 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { Card, Button, Input, Modal, CardSkeleton, Toggle, ConfirmModal } from "@/shared/components";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 import { fetchCached, invalidateCache } from "@/shared/utils/fetchCache";
-import { getCurrentLocale, onLocaleChange } from "@/i18n/runtime";
 import {
-  WENYAN_LOCALES,
   TUNNEL_BENEFITS,
   TUNNEL_PING_INTERVAL_MS,
   TUNNEL_PING_MAX_MS,
   STATUS_POLL_FAST_MS,
   REACHABLE_MISS_THRESHOLD,
   CLIENT_PING_FAST_MS,
-  CAVEMAN_LEVELS,
-  PONYTAIL_LEVELS,
 } from "./endpointConstants";
 import { clientPingUrl, clientPingAny } from "./endpointPing";
 import EndpointRow from "./components/EndpointRow";
@@ -62,19 +58,6 @@ export default function APIPageClient({ machineId }) {
   const [requireLogin, setRequireLogin] = useState(true);
   const [hasPassword, setHasPassword] = useState(true);
   const [tunnelDashboardAccess, setTunnelDashboardAccess] = useState(false);
-  const [rtkEnabled, setRtkEnabledState] = useState(true);
-  const [headroomEnabled, setHeadroomEnabled] = useState(false);
-  const [headroomUrl, setHeadroomUrl] = useState("http://localhost:8787");
-  const [headroomCompressUserMessages, setHeadroomCompressUserMessages] = useState(false);
-  const [headroomStatus, setHeadroomStatus] = useState({ installed: false, running: false, python: null, loading: true });
-  const [showHeadroomInstallModal, setShowHeadroomInstallModal] = useState(false);
-  const [headroomActionLoading, setHeadroomActionLoading] = useState(false);
-  const [headroomActionError, setHeadroomActionError] = useState("");
-  const [cavemanEnabled, setCavemanEnabled] = useState(false);
-  const [cavemanLevel, setCavemanLevel] = useState("full");
-  const [ponytailEnabled, setPonytailEnabled] = useState(false);
-  const [ponytailLevel, setPonytailLevel] = useState("full");
-  const [locale, setLocale] = useState("en");
 
   // Cloudflare Tunnel state
   const [tunnelChecking, setTunnelChecking] = useState(true);
@@ -124,12 +107,11 @@ export default function APIPageClient({ machineId }) {
   const [visibleKeys, setVisibleKeys] = useState(new Set());
 
   /* eslint-disable react-hooks/set-state-in-effect, react-hooks/immutability --
-     The useEffects below intentionally run once on mount (locale detection,
-     bootstrap fetch, scroll-into-view, status poll) or sync external state
-     changes back into the UI (caveman level reset when locale changes). The
-     handler functions they call (syncTunnelStatus, loadSettings, patchSetting,
-     fetchData) are declared further down in this 2000-line file, which is
-     a static-analysis limitation, not a runtime bug — closures capture the
+     The useEffects below intentionally run once on mount (bootstrap fetch,
+     scroll-into-view, status poll) or sync external state changes back into
+     the UI. The handler functions they call (syncTunnelStatus, loadSettings,
+     fetchData) are declared further down in this file, which is a
+     static-analysis limitation, not a runtime bug — closures capture the
      declarations correctly when the effects run. */
 
   // Client-side local/remote detection (UI hint only, not a security gate)
@@ -139,29 +121,6 @@ export default function APIPageClient({ machineId }) {
       // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time client-only detection on mount.
       setIsRemoteHost(!["localhost", "127.0.0.1", "::1"].includes(window.location.hostname));
   }, []);
-
-  // Track app UI locale to gate wenyan caveman levels
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time locale sync on mount; effect is intentional, not a derived value.
-    setLocale(getCurrentLocale());
-    return onLocaleChange(() => setLocale(getCurrentLocale()));
-  }, []);
-
-  const isWenyanLocale = WENYAN_LOCALES.includes(locale);
-  const visibleCavemanLevels = isWenyanLocale
-    ? CAVEMAN_LEVELS
-    : CAVEMAN_LEVELS.filter((lvl) => !lvl.wenyan);
-
-  // Reset wenyan level to "ultra" when leaving a Chinese locale
-  // eslint-disable-next-line react-hooks/immutability -- patchSetting is declared further down in the file; captured by closure at runtime.
-  useEffect(() => {
-    const current = CAVEMAN_LEVELS.find((lvl) => lvl.id === cavemanLevel);
-    if (current?.wenyan && !isWenyanLocale) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- syncs external UI locale change back into local storage; effect is intentional.
-      setCavemanLevel("ultra");
-      patchSetting({ cavemanLevel: "ultra" });
-    }
-  }, [isWenyanLocale, cavemanLevel]);
 
   const { copied, copy } = useCopyToClipboard();
 
@@ -292,15 +251,6 @@ export default function APIPageClient({ machineId }) {
         setRequireLogin(data.requireLogin !== false);
         setHasPassword(data.hasPassword || false);
         setTunnelDashboardAccess(data.tunnelDashboardAccess || false);
-        setRtkEnabledState(data.rtkEnabled !== false);
-        setHeadroomEnabled(!!data.headroomEnabled);
-        setHeadroomUrl(data.headroomUrl || "http://localhost:8787");
-        setHeadroomCompressUserMessages(!!data.headroomCompressUserMessages);
-        refreshHeadroomStatus();
-        setCavemanEnabled(!!data.cavemanEnabled);
-        setCavemanLevel(data.cavemanLevel || "full");
-        setPonytailEnabled(!!data.ponytailEnabled);
-        setPonytailLevel(data.ponytailLevel || "full");
       }
       if (statusRes.ok) {
         const data = await statusRes.json();
@@ -365,106 +315,6 @@ export default function APIPageClient({ machineId }) {
     } catch (error) {
       console.log("Error updating allowRemoteNoApiKey:", error);
     }
-  };
-
-  const handleRtkEnabled = async (value) => {
-    try {
-      const res = await fetch("/api/settings", {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ rtkEnabled: value }),
-      });
-      if (res.ok) setRtkEnabledState(value);
-    } catch (error) {
-      console.log("Error updating rtkEnabled:", error);
-    }
-  };
-
-  const patchSetting = async (patch) => {
-    try {
-      await fetch("/api/settings", {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(patch),
-      });
-    } catch (error) {
-      console.log("Error updating setting:", error);
-    }
-  };
-
-  const handleCavemanEnabled = (value) => {
-    setCavemanEnabled(value);
-    patchSetting({ cavemanEnabled: value });
-  };
-
-  const handleHeadroomEnabled = (value) => {
-    const nextUrl = headroomUrl.trim() || "http://localhost:8787";
-    setHeadroomUrl(nextUrl);
-    setHeadroomEnabled(value);
-    patchSetting({ headroomEnabled: value, headroomUrl: nextUrl });
-  };
-
-  const handleHeadroomUrlBlur = async () => {
-    const next = headroomUrl.trim() || "http://localhost:8787";
-    setHeadroomUrl(next);
-    await patchSetting({ headroomUrl: next });
-    refreshHeadroomStatus();
-  };
-
-  const handleHeadroomCompressUserMessages = (value) => {
-    setHeadroomCompressUserMessages(value);
-    patchSetting({ headroomCompressUserMessages: value });
-  };
-
-  const refreshHeadroomStatus = useCallback(async () => {
-    setHeadroomStatus((s) => ({ ...s, loading: true }));
-    try {
-      const res = await fetch("/api/headroom/status", { headers: { "Cache-Control": "no-store" } });
-      const data = await res.json();
-      setHeadroomStatus({ ...data, loading: false });
-    } catch {
-      setHeadroomStatus({ installed: false, running: false, python: null, loading: false });
-    }
-  }, []);
-
-  const handleHeadroomStart = useCallback(async () => {
-    setHeadroomActionError("");
-    setHeadroomActionLoading(true);
-    try {
-      const res = await fetch("/api/headroom/start", { method: "POST" });
-      const data = await res.json().catch(() => ({}));
-      if (!res.ok) throw new Error(data.error || "Failed to start proxy");
-      await refreshHeadroomStatus();
-    } catch (e) {
-      setHeadroomActionError(e.message);
-    } finally {
-      setHeadroomActionLoading(false);
-    }
-  }, [refreshHeadroomStatus]);
-
-  const handleHeadroomStop = useCallback(async () => {
-    setHeadroomActionLoading(true);
-    try {
-      await fetch("/api/headroom/stop", { method: "POST" });
-      await refreshHeadroomStatus();
-    } finally {
-      setHeadroomActionLoading(false);
-    }
-  }, [refreshHeadroomStatus]);
-
-  const handleCavemanLevel = (level) => {
-    setCavemanLevel(level);
-    patchSetting({ cavemanLevel: level });
-  };
-
-  const handlePonytailEnabled = (value) => {
-    setPonytailEnabled(value);
-    patchSetting({ ponytailEnabled: value });
-  };
-
-  const handlePonytailLevel = (level) => {
-    setPonytailLevel(level);
-    patchSetting({ ponytailLevel: level });
   };
 
   // ── ACL Edit Key handlers ──────────────────────────────────────────
@@ -1135,19 +985,6 @@ export default function APIPageClient({ machineId }) {
   }
 
   const currentEndpoint = baseUrl;
-  const headroomRunning = !!headroomStatus.running;
-  const headroomLocalUrl = headroomStatus.localUrl !== false;
-  const headroomCanStart = !!headroomStatus.canStart;
-  const headroomManaged = headroomLocalUrl && !!headroomStatus.managedPid;
-  const headroomStatusLabel = headroomStatus.loading
-    ? "Checking…"
-    : headroomRunning
-      ? "Running"
-      : headroomLocalUrl && !headroomStatus.installed
-        ? "Not installed"
-        : headroomLocalUrl
-          ? "Proxy off"
-          : "Unreachable";
 
   return (
     <div className="flex flex-col gap-8">
@@ -1403,167 +1240,6 @@ export default function APIPageClient({ machineId }) {
             </div>
           </div>
         )}
-      </Card>
-
-      {/* Token Saver (RTK + Caveman + Ponytail + Headroom) */}
-      <Card id="rtk">
-        <div className="flex items-center justify-between mb-2">
-          <h2 className="text-lg font-semibold flex items-center gap-2">
-            <span className="material-symbols-outlined text-primary">bolt</span>
-            Token Saver
-          </h2>
-        </div>
-        <div className="flex items-center justify-between pt-2 pb-4 border-b border-border gap-4">
-          <div className="min-w-0 flex-1">
-            <p className="font-medium">
-              Compress tool output{" "}
-              <a
-                href="https://github.com/rtk-ai/rtk"
-                target="_blank"
-                rel="noreferrer"
-                className="text-xs font-normal text-primary underline hover:opacity-80"
-              >
-                (RTK)
-              </a>
-            </p>
-            <p className="text-sm text-text-muted">
-              git/grep/ls/tree/logs → 60-90% fewer input tokens
-            </p>
-          </div>
-          <Toggle
-            checked={rtkEnabled}
-            onChange={() => handleRtkEnabled(!rtkEnabled)}
-          />
-        </div>
-        <div className="flex items-center justify-between py-4 border-b border-border gap-4 flex-wrap">
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-3 flex-wrap">
-              <p className="font-medium">
-                Compress context{" "}
-                <a
-                  href="https://github.com/chopratejas/headroom"
-                  target="_blank"
-                  rel="noreferrer"
-                  className="text-xs font-normal text-primary underline hover:opacity-80"
-                >
-                  (Headroom)
-                </a>
-              </p>
-              <span className={`text-xs px-2 py-0.5 rounded ${headroomRunning ? "bg-success/15 text-success" : "bg-warning/15 text-warning"}`}>
-                {headroomStatusLabel}
-              </span>
-              <button
-                type="button"
-                onClick={() => setShowHeadroomInstallModal(true)}
-                className="text-xs text-primary underline hover:opacity-80"
-              >
-                  {headroomRunning ? "Manage" : "Setup"}
-              </button>
-            </div>
-            <p className="text-sm text-text-muted mt-1">
-              Compress prompts via /v1/compress before routing to the model
-            </p>
-          </div>
-          <Toggle
-            checked={headroomEnabled && headroomRunning}
-            disabled={!headroomRunning}
-            onChange={() => handleHeadroomEnabled(!headroomEnabled)}
-          />
-        </div>
-        <div className="flex items-center justify-between pt-4 gap-4 flex-wrap">
-          <div className="min-w-0 flex-1">
-            <p className="font-medium">
-              Compress LLM output{" "}
-              <a
-                href="https://github.com/JuliusBrussee/caveman"
-                target="_blank"
-                rel="noreferrer"
-                className="text-xs font-normal text-primary underline hover:opacity-80"
-              >
-                (Caveman)
-              </a>
-            </p>
-            <p className="text-sm text-text-muted">
-              Terse-style system prompt → ~65% fewer output tokens (up to 87%)
-            </p>
-          </div>
-          <div className="flex items-center gap-3 shrink-0">
-            {cavemanEnabled && (
-              <div className="flex flex-col items-end gap-1">
-                <div className="flex items-center gap-1.5">
-                  {visibleCavemanLevels.map((lvl) => (
-                    <button
-                      key={lvl.id}
-                      onClick={() => handleCavemanLevel(lvl.id)}
-                      className={`px-3 py-1.5 rounded text-xs font-medium border transition-colors ${
-                        cavemanLevel === lvl.id
-                          ? "bg-primary text-white border-primary"
-                          : "bg-transparent border-border text-text-muted hover:bg-surface-2"
-                      }`}
-                      title={lvl.desc}
-                    >
-                      {lvl.label}
-                    </button>
-                  ))}
-                </div>
-                <p className="text-xs text-primary">
-                  {CAVEMAN_LEVELS.find((lvl) => lvl.id === cavemanLevel)?.desc}
-                </p>
-              </div>
-            )}
-            <Toggle
-              checked={cavemanEnabled}
-              onChange={() => handleCavemanEnabled(!cavemanEnabled)}
-            />
-          </div>
-        </div>
-        <div className="flex items-center justify-between pt-4 mt-4 border-t border-border gap-4 flex-wrap">
-          <div className="min-w-0 flex-1">
-            <p className="font-medium">
-              Lazy senior dev{" "}
-              <a
-                href="https://github.com/DietrichGebert/ponytail"
-                target="_blank"
-                rel="noreferrer"
-                className="text-xs font-normal text-primary underline hover:opacity-80"
-              >
-                (Ponytail)
-              </a>
-            </p>
-            <p className="text-sm text-text-muted">
-              Bias the model toward minimal code: YAGNI, reuse stdlib, deletion over addition
-            </p>
-          </div>
-          <div className="flex items-center gap-3 shrink-0">
-            {ponytailEnabled && (
-              <div className="flex flex-col items-end gap-1">
-                <div className="flex items-center gap-1.5">
-                  {PONYTAIL_LEVELS.map((lvl) => (
-                    <button
-                      key={lvl.id}
-                      onClick={() => handlePonytailLevel(lvl.id)}
-                      className={`px-3 py-1.5 rounded text-xs font-medium border transition-colors ${
-                        ponytailLevel === lvl.id
-                          ? "bg-primary text-white border-primary"
-                          : "bg-transparent border-border text-text-muted hover:bg-surface-2"
-                      }`}
-                      title={lvl.desc}
-                    >
-                      {lvl.label}
-                    </button>
-                  ))}
-                </div>
-                <p className="text-xs text-primary">
-                  {PONYTAIL_LEVELS.find((lvl) => lvl.id === ponytailLevel)?.desc}
-                </p>
-              </div>
-            )}
-            <Toggle
-              checked={ponytailEnabled}
-              onChange={() => handlePonytailEnabled(!ponytailEnabled)}
-            />
-          </div>
-        </div>
       </Card>
 
       {/* API Keys */}
@@ -2206,67 +1882,6 @@ This key will stop working immediately but can be resumed later.`,
               {tsLoading ? "Disabling..." : "Disable"}
             </Button>
             <Button onClick={() => setShowDisableTsModal(false)} variant="ghost" fullWidth disabled={tsLoading}>Cancel</Button>
-          </div>
-        </div>
-      </Modal>
-
-      {/* Headroom Install Guide Modal */}
-      <Modal
-        isOpen={showHeadroomInstallModal}
-        title={headroomRunning ? "Headroom" : "Setup Headroom"}
-        onClose={() => setShowHeadroomInstallModal(false)}
-      >
-        <div className="flex flex-col gap-4">
-          <div className="flex items-center justify-between text-sm">
-            <span>Status</span>
-            <span className={headroomRunning ? "text-success" : "text-warning"}>
-              {headroomStatusLabel}
-            </span>
-          </div>
-          <div className="flex flex-col gap-1">
-            <p className="text-sm font-medium">Proxy URL</p>
-            <Input
-              value={headroomUrl}
-              onChange={(e) => setHeadroomUrl(e.target.value)}
-              onBlur={handleHeadroomUrlBlur}
-              placeholder="http://localhost:8787"
-              className="font-mono text-sm"
-            />
-            <p className="text-xs text-text-muted">
-              Use a local proxy for Start/Stop, or an external Docker sidecar like http://headroom:8787.
-            </p>
-          </div>
-          {headroomManaged ? (
-            <Button onClick={handleHeadroomStop} variant="ghost" fullWidth disabled={headroomActionLoading}>
-              {headroomActionLoading ? "Stopping…" : "Stop Headroom"}
-            </Button>
-          ) : headroomRunning ? (
-            <p className="text-sm text-success">Headroom proxy is reachable. You can enable the token saver.</p>
-          ) : headroomCanStart ? (
-            <Button onClick={handleHeadroomStart} fullWidth disabled={headroomActionLoading}>
-              {headroomActionLoading ? "Starting…" : "Start Headroom"}
-            </Button>
-          ) : !headroomLocalUrl ? (
-            <p className="text-sm text-warning">Start Headroom separately at the configured URL, then recheck.</p>
-          ) : !headroomStatus.python ? (
-            <p className="text-sm text-warning">Python ≥ 3.10 required for local managed mode. Install Python first, or use an external proxy URL.</p>
-          ) : (
-            <div className="flex flex-col gap-1">
-              <p className="text-sm font-medium">Install then click Start:</p>
-              <div className="flex items-center gap-2">
-                <pre className="flex-1 rounded bg-black/5 dark:bg-white/5 p-2 text-xs font-mono overflow-x-auto">{`pip install "headroom-ai[proxy]"`}</pre>
-                <Button size="sm" variant="ghost" onClick={() => copy(`pip install "headroom-ai[proxy]"`)}>
-                  {copied ? "Copied" : "Copy"}
-                </Button>
-              </div>
-            </div>
-          )}
-          {headroomActionError && (
-            <p className="text-sm text-warning">{headroomActionError}</p>
-          )}
-          <div className="flex gap-2">
-            <Button onClick={() => refreshHeadroomStatus()} variant="ghost" fullWidth>Recheck</Button>
-            <Button onClick={() => setShowHeadroomInstallModal(false)} fullWidth>Done</Button>
           </div>
         </div>
       </Modal>

--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
@@ -38,10 +38,24 @@ export default function APIPageClient({ machineId }) {
   const [editKindsAll, setEditKindsAll] = useState(true); // null = all
   const [editProvidersAll, setEditProvidersAll] = useState(true);
   const [editCombosAll, setEditCombosAll] = useState(true);
+  const [editModelsAll, setEditModelsAll] = useState(true);
+  const [editModels, setEditModels] = useState([]); // selected model ids (provider/model)
+  const [editModelsByProvider, setEditModelsByProvider] = useState({}); // providerId → [modelId]
   const [editSaving, setEditSaving] = useState(false);
+  // Limit edit state (empty string = unlimited)
+  const [editExpiresAt, setEditExpiresAt] = useState("");
+  const [editMaxTokens, setEditMaxTokens] = useState("");
+  const [editMaxTokensDaily, setEditMaxTokensDaily] = useState("");
+  const [editRpm, setEditRpm] = useState("");
+  const [editRph, setEditRph] = useState("");
+  const [editRpd, setEditRpd] = useState("");
+  const [editTokens5h, setEditTokens5h] = useState("");
+  const [editTokensWeekly, setEditTokensWeekly] = useState("");
+  const [editTokensMonthly, setEditTokensMonthly] = useState("");
   const [providerList, setProviderList] = useState([]);
   const [aliasMap, setAliasMap] = useState({}); // alias → provider ID
   const [comboList, setComboList] = useState([]);
+  const [allModelsCatalog, setAllModelsCatalog] = useState([]); // {id, provider, model}[]
 
   const [requireApiKey, setRequireApiKey] = useState(false);
   const [allowRemoteNoApiKey, setAllowRemoteNoApiKey] = useState(false);
@@ -256,6 +270,10 @@ export default function APIPageClient({ machineId }) {
       const tsUrlVal = data.tailscale?.tunnelUrl || "";
       setTsUrl(tsUrlVal);
       setTsEnabled(tsEn);
+      if (data.tailscale?.authUrl) {
+        setTsAuthUrl(data.tailscale.authUrl);
+        setTsAuthLabel("Open Login Page");
+      }
       updateReachable(null, tsClientReachableRef, tsMissRef, setTsReachable, tsEverReachableRef, setTsEverReachable);
     } catch { /* ignore poll errors */ }
   };
@@ -297,6 +315,10 @@ export default function APIPageClient({ machineId }) {
         const tsUrlVal = data.tailscale?.tunnelUrl || "";
         setTsUrl(tsUrlVal);
         setTsEnabled(tsEn);
+        if (data.tailscale?.authUrl) {
+          setTsAuthUrl(data.tailscale.authUrl);
+          setTsAuthLabel("Open Login Page");
+        }
         updateReachable(null, tsClientReachableRef, tsMissRef, setTsReachable, tsEverReachableRef, setTsEverReachable);
       }
     } catch (error) {
@@ -475,17 +497,30 @@ export default function APIPageClient({ machineId }) {
     }).sort((a, b) => a.displayName.localeCompare(b.displayName));
   };
 
-  const handleOpenEditKey = (key) => {
+  const handleOpenEditKey = async (key) => {
     setEditingKey(key);
     setEditName(key.name || "");
+    setEditExpiresAt(key.expiresAt ? key.expiresAt.slice(0, 16) : "");
+    setEditMaxTokens(key.maxTokens ?? "");
+    setEditMaxTokensDaily(key.maxTokensDaily ?? "");
+    setEditRpm(key.rpm ?? "");
+    setEditRph(key.rph ?? "");
+    setEditRpd(key.rpd ?? "");
+    setEditTokens5h(key.tokens5h ?? "");
+    setEditTokensWeekly(key.tokensWeekly ?? "");
+    setEditTokensMonthly(key.tokensMonthly ?? "");
     const ap = key.allowedProviders;
     const ac = key.allowedCombos;
     const ak = key.allowedKinds;
+    const am = key.allowedModels;
     setEditProvidersAll(!ap);
     setEditCombosAll(!ac);
     setEditKindsAll(!ak);
+    setEditModelsAll(!am);
     setEditCombos(ac || []);
     setEditKinds(ak || []);
+    setEditModels(am || []);
+    setEditModelsByProvider({});
 
     // Resolve stored ACL provider values to provider IDs in our list
     // Stored values can be: full provider ID, prefix (e.g. "tr"), or alias (e.g. "oc", "qd", "kc")
@@ -508,16 +543,52 @@ export default function APIPageClient({ machineId }) {
     } else {
       setEditProviders([]);
     }
+
+    // Lazy-load model catalog for per-provider model ACL
+    if (allModelsCatalog.length === 0) {
+      try {
+        const res = await fetch("/api/models", { cache: "no-store" });
+        if (res.ok) {
+          const data = await res.json();
+          const list = Array.isArray(data?.models) ? data.models : [];
+          setAllModelsCatalog(list.map((m) => ({
+            id: m.id || `${m.provider}/${m.model}`,
+            provider: m.provider || (m.id || "").split("/")[0],
+            model: m.model || (m.id || "").split("/").slice(1).join("/"),
+            alias: m.alias || null,
+          })));
+        }
+      } catch { /* ignore */ }
+    }
   };
 
   const handleSaveEditKey = async () => {
     if (!editingKey) return;
     setEditSaving(true);
     try {
+      const parseNum = (v) => {
+        const s = String(v).trim();
+        if (s === "" || s === "null" || s === "undefined") return null;
+        const n = Number(s);
+        return Number.isFinite(n) && n >= 0 ? n : null;
+      };
       const body = {
+        name: editName.trim() || editingKey.name,
         allowedProviders: editProvidersAll ? null : editProviders,
         allowedCombos: editCombosAll ? null : editCombos,
         allowedKinds: editKindsAll ? null : editKinds,
+        allowedModels: editModelsAll ? null : editModels,
+        limits: {
+            expiresAt: editExpiresAt ? new Date(editExpiresAt).toISOString() : null,
+            maxTokens: parseNum(editMaxTokens),
+            maxTokensDaily: parseNum(editMaxTokensDaily),
+            rpm: parseNum(editRpm),
+            rph: parseNum(editRph),
+            rpd: parseNum(editRpd),
+            tokens5h: parseNum(editTokens5h),
+            tokensWeekly: parseNum(editTokensWeekly),
+            tokensMonthly: parseNum(editTokensMonthly),
+          },
       };
       const res = await fetch(`/api/keys/${editingKey.id}`, {
         method: "PUT",
@@ -546,6 +617,16 @@ export default function APIPageClient({ machineId }) {
 
   const toggleEditKind = (kind) => {
     setEditKinds((prev) => prev.includes(kind) ? prev.filter((k) => k !== kind) : [...prev, kind]);
+  };
+
+  const toggleEditModel = (modelId) => {
+    setEditModels((prev) => prev.includes(modelId) ? prev.filter((m) => m !== modelId) : [...prev, modelId]);
+  };
+
+  const modelsForProvider = (providerId) => {
+    const p = providerList.find((x) => x.id === providerId);
+    const aliases = new Set([providerId, p?.alias, p?.prefix].filter(Boolean));
+    return allModelsCatalog.filter((m) => aliases.has(m.provider) || (m.id || "").startsWith(`${providerId}/`) || (p?.alias && (m.id || "").startsWith(`${p.alias}/`)));
   };
 
   const fetchData = async () => {
@@ -808,9 +889,13 @@ export default function APIPageClient({ machineId }) {
 
       if (res.ok && data.success) {
         setTsUrl(data.tunnelUrl || "");
-        const reachable = await pingTsHealth(data.tunnelUrl);
+        let reachable = false;
+        if (data.tunnelUrl) {
+          reachable = await pingTsHealth(data.tunnelUrl);
+        }
         setTsEnabled(true);
-        setTsStatus(reachable ? null : { type: "warning", message: "Connected but not reachable yet." });
+        setTsReachable(reachable);
+        setTsStatus(reachable ? null : { type: "warning", message: data.tunnelUrl ? "Connected but not reachable yet." : "Tailscale connected, but no Funnel URL was returned yet." });
         return;
       }
 
@@ -830,9 +915,10 @@ export default function APIPageClient({ machineId }) {
                 const data2 = await res2.json();
                 if (res2.ok && data2.success) {
                   setTsUrl(data2.tunnelUrl || "");
-                  const ok2 = await pingTsHealth(data2.tunnelUrl);
+                  const ok2 = data2.tunnelUrl ? await pingTsHealth(data2.tunnelUrl) : false;
                   setTsEnabled(true);
-                  setTsStatus(ok2 ? null : { type: "warning", message: "Connected but not reachable yet." });
+                  setTsReachable(ok2);
+                  setTsStatus(ok2 ? null : { type: "warning", message: data2.tunnelUrl ? "Connected but not reachable yet." : "Tailscale connected, but no Funnel URL was returned yet." });
                 } else if (data2.funnelNotEnabled && data2.enableUrl) {
                   await pollFunnelEnable(data2.enableUrl);
                 } else {
@@ -843,8 +929,7 @@ export default function APIPageClient({ machineId }) {
             }
           } catch { /* retry */ }
         }
-        clearUserAuth();
-        setTsStatus({ type: "error", message: "Login timed out. Please try again." });
+        setTsStatus({ type: "warning", message: "Login is still pending. Open the login page, then click Enable again after logging in." });
         return;
       }
 
@@ -860,7 +945,6 @@ export default function APIPageClient({ machineId }) {
       setTsLoading(false);
       setTsConnecting(false);
       setTsProgress("");
-      clearUserAuth();
     }
   };
 
@@ -875,9 +959,10 @@ export default function APIPageClient({ machineId }) {
         if (res.ok && data.success) {
           clearUserAuth();
           setTsUrl(data.tunnelUrl || "");
-          const ok3 = await pingTsHealth(data.tunnelUrl);
+          const ok3 = data.tunnelUrl ? await pingTsHealth(data.tunnelUrl) : false;
           setTsEnabled(true);
-          setTsStatus(ok3 ? null : { type: "warning", message: "Connected but not reachable yet." });
+          setTsReachable(ok3);
+          setTsStatus(ok3 ? null : { type: "warning", message: data.tunnelUrl ? "Connected but not reachable yet." : "Tailscale connected, but no Funnel URL was returned yet." });
           return;
         }
         if (data.funnelNotEnabled) continue;
@@ -988,6 +1073,37 @@ export default function APIPageClient({ machineId }) {
   const maskKey = (fullKey) => {
     if (!fullKey || fullKey.length <= 10) return fullKey || "";
     return fullKey.slice(0, 6) + "•".repeat(fullKey.length - 10) + fullKey.slice(-4);
+  };
+
+
+  const formatQuotaValue = (value) => {
+    if (value === null || value === undefined) return "∞";
+    return Number(value).toLocaleString();
+  };
+
+  const getKeyStatusMeta = (key) => {
+    const status = key.usage?.status || (key.isActive === false ? "paused" : "ok");
+    const map = {
+      ok: { label: "Healthy", icon: "check_circle", cls: "bg-green-500/10 text-green-600 dark:text-green-400" },
+      warning: { label: "Watch", icon: "warning", cls: "bg-yellow-500/10 text-yellow-600 dark:text-yellow-400" },
+      danger: { label: "Near limit", icon: "error", cls: "bg-orange-500/10 text-orange-600 dark:text-orange-400" },
+      blocked: { label: "Blocked", icon: "block", cls: "bg-red-500/10 text-red-600 dark:text-red-400" },
+      paused: { label: "Paused", icon: "pause_circle", cls: "bg-slate-500/10 text-slate-500" },
+    };
+    return map[status] || map.ok;
+  };
+
+  const quotaMetrics = (key) => {
+    const metrics = key.usage?.metrics || {};
+    return ["rpm", "rph", "rpd", "maxTokensDaily", "tokens5h", "tokensWeekly", "tokensMonthly"]
+      .map((id) => ({ id, ...(metrics[id] || {}) }))
+      .filter((m) => m.limit !== null && m.limit !== undefined);
+  };
+
+  const quotaBarClass = (status) => {
+    if (status === "blocked" || status === "danger") return "bg-red-500";
+    if (status === "warning") return "bg-yellow-500";
+    return "bg-primary";
   };
 
   const toggleKeyVisibility = (keyId) => {
@@ -1172,6 +1288,15 @@ export default function APIPageClient({ machineId }) {
                   <span className="material-symbols-outlined animate-spin text-sm">progress_activity</span>
                   {tsEverReachable ? "Tailscale reconnecting..." : "Tailscale checking..."}
                 </div>
+                {tsAuthUrl && (
+                  <Button
+                    size="sm"
+                    icon="open_in_new"
+                    onClick={() => window.open(tsAuthUrl, "tailscale_auth", "width=600,height=700,noopener,noreferrer")}
+                  >
+                    {tsAuthLabel || "Open Login Page"}
+                  </Button>
+                )}
                 <button
                   onClick={() => setShowDisableTsModal(true)}
                   className="p-2 hover:bg-red-500/10 rounded text-red-500 transition-colors shrink-0"
@@ -1495,6 +1620,23 @@ export default function APIPageClient({ machineId }) {
           </div>
         )}
 
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-4">
+          <div className="rounded-xl border border-border/50 bg-surface/40 p-4">
+            <p className="text-xs text-text-muted">Total keys</p>
+            <p className="text-2xl font-semibold mt-1">{keys.length}</p>
+          </div>
+          <div className="rounded-xl border border-border/50 bg-surface/40 p-4">
+            <p className="text-xs text-text-muted">Active</p>
+            <p className="text-2xl font-semibold mt-1 text-green-500">{keys.filter((k) => k.isActive !== false).length}</p>
+          </div>
+          <div className="rounded-xl border border-border/50 bg-surface/40 p-4">
+            <p className="text-xs text-text-muted">Needs attention</p>
+            <p className="text-2xl font-semibold mt-1 text-orange-500">
+              {keys.filter((k) => ["warning", "danger", "blocked", "paused"].includes(k.usage?.status || (k.isActive === false ? "paused" : "ok"))).length}
+            </p>
+          </div>
+        </div>
+
         {keys.length === 0 ? (
           <div className="text-center py-12">
             <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-primary/10 text-primary mb-4">
@@ -1507,110 +1649,125 @@ export default function APIPageClient({ machineId }) {
             </Button>
           </div>
         ) : (
-          <div className="flex flex-col">
-            {keys.map((key) => (
-              <div
-                key={key.id}
-                className={`group flex items-center justify-between py-3 border-b border-black/[0.03] dark:border-white/[0.03] last:border-b-0 ${key.isActive === false ? "opacity-60" : ""}`}
-              >
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium">{key.name}</p>
-                  <div className="flex items-center gap-2 mt-1">
-                    <code className="text-xs text-text-muted font-mono">
-                      {visibleKeys.has(key.id) ? key.key : maskKey(key.key)}
-                    </code>
-                    <button
-                      onClick={() => toggleKeyVisibility(key.id)}
-                      className="p-1 hover:bg-black/5 dark:hover:bg-white/5 rounded text-text-muted hover:text-primary opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-all"
-                      title={visibleKeys.has(key.id) ? "Hide key" : "Show key"}
-                    >
-                      <span className="material-symbols-outlined text-[14px]">
-                        {visibleKeys.has(key.id) ? "visibility_off" : "visibility"}
-                      </span>
-                    </button>
-                    <button
-                      onClick={() => copy(key.key, key.id)}
-                      className="p-1 hover:bg-black/5 dark:hover:bg-white/5 rounded text-text-muted hover:text-primary opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-all"
-                    >
-                      <span className="material-symbols-outlined text-[14px]">
-                        {copied === key.id ? "check" : "content_copy"}
-                      </span>
-                    </button>
-                  </div>
-                  <p className="text-xs text-text-muted mt-1">
-                    Created {new Date(key.createdAt).toLocaleDateString()}
-                  </p>
-                   {key.isActive === false && (
-                    <p className="text-xs text-orange-500 mt-1">Paused</p>
-                  )}
-                   {/* ACL badges */}
-                  {(key.allowedProviders || key.allowedCombos || key.allowedKinds) && (
-                    <div className="flex flex-wrap gap-1 mt-1">
-                      {key.allowedProviders && (
-                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-500 dark:bg-blue-500/20" title={key.allowedProviders.join(", ")}>
-                          {key.allowedProviders.length === 0
-                            ? "No providers"
-                            : key.allowedProviders.map((stored) => {
-                                // Try providerList first (has connections)
-                                const p = providerList.find((pp) => pp.id === stored || pp.alias === stored || pp.prefix === stored);
-                                if (p) return p.displayName;
-                                // Try aliasMap for providers without connections
-                                const resolved = aliasMap[stored];
-                                if (resolved) return resolved;
-                                return stored;
-                              }).join(", ")}
+          <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
+            {keys.map((key) => {
+              const statusMeta = getKeyStatusMeta(key);
+              const metrics = quotaMetrics(key);
+              return (
+                <div
+                  key={key.id}
+                  className={`group rounded-2xl border border-border/60 bg-surface/50 p-4 shadow-sm ${key.isActive === false ? "opacity-70" : ""}`}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <p className="text-sm font-semibold truncate">{key.name}</p>
+                        <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium ${statusMeta.cls}`}>
+                          <span className="material-symbols-outlined text-[13px]">{statusMeta.icon}</span>
+                          {statusMeta.label}
                         </span>
-                      )}
-                      {key.allowedCombos && (
-                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-purple-500/10 text-purple-500 dark:bg-purple-500/20">
-                          {key.allowedCombos.length === 0 ? "No combos" : key.allowedCombos.join(", ")}
-                        </span>
-                      )}
-                      {key.allowedKinds && (
-                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-green-500/10 text-green-500 dark:bg-green-500/20">
-                          {key.allowedKinds.length === 0 ? "No kinds" : key.allowedKinds.join(", ")}
-                        </span>
-                      )}
+                      </div>
+                      <div className="flex items-center gap-2 mt-2">
+                        <code className="text-xs text-text-muted font-mono truncate">
+                          {visibleKeys.has(key.id) ? key.key : maskKey(key.key)}
+                        </code>
+                        <button
+                          onClick={() => toggleKeyVisibility(key.id)}
+                          className="p-1 hover:bg-black/5 dark:hover:bg-white/5 rounded text-text-muted hover:text-primary transition-all"
+                          title={visibleKeys.has(key.id) ? "Hide key" : "Show key"}
+                        >
+                          <span className="material-symbols-outlined text-[14px]">
+                            {visibleKeys.has(key.id) ? "visibility_off" : "visibility"}
+                          </span>
+                        </button>
+                        <button
+                          onClick={() => copy(key.key, key.id)}
+                          className="p-1 hover:bg-black/5 dark:hover:bg-white/5 rounded text-text-muted hover:text-primary transition-all"
+                        >
+                          <span className="material-symbols-outlined text-[14px]">
+                            {copied === key.id ? "check" : "content_copy"}
+                          </span>
+                        </button>
+                      </div>
+                      <p className="text-xs text-text-muted mt-1">
+                        Created {new Date(key.createdAt).toLocaleDateString()}
+                        {key.expiresAt ? ` · Expires ${new Date(key.expiresAt).toLocaleString()}` : " · No expiry"}
+                      </p>
                     </div>
-                  )}
-                </div>
-                <div className="flex items-center gap-2">
-                  {/* Edit ACL button */}
-                  <button
-                    onClick={() => handleOpenEditKey(key)}
-                    className="p-2 hover:bg-primary/10 rounded text-primary opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-all"
-                    title="Edit access control"
-                  >
-                    <span className="material-symbols-outlined text-[18px]">tune</span>
-                  </button>
-                  <Toggle
-                    size="sm"
-                    checked={key.isActive ?? true}
-                    onChange={(checked) => {
-                      if (key.isActive && !checked) {
-                        setConfirmState({
-                          title: "Pause API Key",
-                          message: `Pause API key "${key.name}"?\n\nThis key will stop working immediately but can be resumed later.`,
-                          onConfirm: async () => {
-                            setConfirmState(null);
+                    <div className="flex items-center gap-2 shrink-0">
+                      <button
+                        onClick={() => handleOpenEditKey(key)}
+                        className="p-2 hover:bg-primary/10 rounded text-primary transition-all"
+                        title="Edit access control and limits"
+                      >
+                        <span className="material-symbols-outlined text-[18px]">tune</span>
+                      </button>
+                      <Toggle
+                        size="sm"
+                        checked={key.isActive ?? true}
+                        onChange={(checked) => {
+                          if (key.isActive && !checked) {
+                            setConfirmState({
+                              title: "Pause API Key",
+                              message: `Pause API key "${key.name}"?
+
+This key will stop working immediately but can be resumed later.`,
+                              onConfirm: async () => {
+                                setConfirmState(null);
+                                handleToggleKey(key.id, checked);
+                              }
+                            });
+                          } else {
                             handleToggleKey(key.id, checked);
                           }
-                        });
-                      } else {
-                        handleToggleKey(key.id, checked);
-                      }
-                    }}
-                    title={key.isActive ? "Pause key" : "Resume key"}
-                  />
-                  <button
-                    onClick={() => handleDeleteKey(key.id)}
-                    className="p-2 hover:bg-red-500/10 rounded text-red-500 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-all"
-                  >
-                    <span className="material-symbols-outlined text-[18px]">delete</span>
-                  </button>
+                        }}
+                        title={key.isActive ? "Pause key" : "Resume key"}
+                      />
+                      <button
+                        onClick={() => handleDeleteKey(key.id)}
+                        className="p-2 hover:bg-red-500/10 rounded text-red-500 transition-all"
+                      >
+                        <span className="material-symbols-outlined text-[18px]">delete</span>
+                      </button>
+                    </div>
+                  </div>
+
+                  <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-3">
+                    {metrics.length === 0 ? (
+                      <div className="sm:col-span-2 rounded-xl border border-dashed border-border/70 p-3 text-xs text-text-muted">
+                        No quota limits configured. This key is only gated by active/paused state and ACL rules.
+                      </div>
+                    ) : metrics.map((metric) => (
+                      <div key={metric.id} className="rounded-xl border border-border/40 bg-background/40 p-3">
+                        <div className="flex items-center justify-between gap-2 mb-2">
+                          <span className="text-xs font-medium truncate">{metric.label}</span>
+                          <span className="text-[11px] text-text-muted">
+                            {formatQuotaValue(metric.used)} / {formatQuotaValue(metric.limit)}
+                          </span>
+                        </div>
+                        <div className="h-2 rounded-full bg-border/50 overflow-hidden">
+                          <div
+                            className={`h-full rounded-full ${quotaBarClass(metric.status)}`}
+                            style={{ width: `${Math.min(100, metric.percent || 0)}%` }}
+                          />
+                        </div>
+                        <div className="flex items-center justify-between mt-1 text-[10px] text-text-muted">
+                          <span>{metric.percent ?? 0}% used</span>
+                          <span>{formatQuotaValue(metric.remaining)} left</span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+
+                  <div className="flex flex-wrap gap-1.5 mt-4">
+                    {key.allowedProviders && <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-500">{key.allowedProviders.length === 0 ? "No providers" : `${key.allowedProviders.length} providers`}</span>}
+                    {key.allowedCombos && <span className="text-[10px] px-1.5 py-0.5 rounded bg-purple-500/10 text-purple-500">{key.allowedCombos.length === 0 ? "No combos" : `${key.allowedCombos.length} combos`}</span>}
+                    {key.allowedKinds && <span className="text-[10px] px-1.5 py-0.5 rounded bg-green-500/10 text-green-500">{key.allowedKinds.length === 0 ? "No kinds" : key.allowedKinds.join(", ")}</span>}
+                    {key.allowedModels && <span className="text-[10px] px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-600 dark:text-amber-300">{key.allowedModels.length === 0 ? "No models" : `${key.allowedModels.length} models`}</span>}
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </Card>
@@ -1754,6 +1911,62 @@ export default function APIPageClient({ machineId }) {
             {editProvidersAll && <p className="text-xs text-text-muted">This key can access all providers ({providerList.length}).</p>}
           </div>
 
+          {/* Per-provider models */}
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <label className="text-sm font-medium">Models</label>
+              <label className="flex items-center gap-1.5 text-xs cursor-pointer">
+                <input type="checkbox" checked={editModelsAll} onChange={(e) => setEditModelsAll(e.target.checked)} />
+                <span className="text-text-muted">All allowed</span>
+              </label>
+            </div>
+            {!editModelsAll && (
+              <div className="max-h-72 overflow-y-auto border border-border-subtle rounded-lg p-2 space-y-2">
+                {(editProvidersAll ? providerList : providerList.filter((p) => editProviders.includes(p.id))).length === 0 ? (
+                  <p className="text-xs text-text-muted p-2">No providers selected.</p>
+                ) : (
+                  (editProvidersAll ? providerList : providerList.filter((p) => editProviders.includes(p.id))).map((p) => {
+                    const models = modelsForProvider(p.id);
+                    const open = !!editModelsByProvider[p.id];
+                    return (
+                      <div key={p.id} className="border border-border-subtle rounded-md">
+                        <button
+                          type="button"
+                          onClick={() => setEditModelsByProvider((prev) => ({ ...prev, [p.id]: !prev[p.id] }))}
+                          className="w-full flex items-center justify-between px-2 py-1.5 text-xs hover:bg-surface-2 rounded-md"
+                        >
+                          <span className="font-medium">{p.displayName}</span>
+                          <span className="text-text-muted text-[10px]">
+                            {models.filter((m) => editModels.includes(m.id)).length}/{models.length || "?"}
+                            <span className="material-symbols-outlined text-sm align-middle ml-1">{open ? "expand_less" : "expand_more"}</span>
+                          </span>
+                        </button>
+                        {open && (
+                          <div className="px-2 pb-2 space-y-1">
+                            {models.length === 0 ? (
+                              <p className="text-[10px] text-text-muted px-1">No models listed for this provider.</p>
+                            ) : (
+                              models.map((m) => {
+                                const checked = editModels.includes(m.id);
+                                return (
+                                  <label key={m.id} className={`flex items-center gap-2 px-2 py-1 rounded text-[11px] cursor-pointer ${checked ? "bg-primary/10 text-primary" : "hover:bg-surface-2"}`}>
+                                    <input type="checkbox" checked={checked} onChange={() => toggleEditModel(m.id)} className="rounded" />
+                                    <span className="font-mono truncate">{m.alias || m.id}</span>
+                                  </label>
+                                );
+                              })
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })
+                )}
+              </div>
+            )}
+            {editModelsAll && <p className="text-xs text-text-muted">This key can access all models of allowed providers.</p>}
+          </div>
+
           {/* Combos */}
           <div>
             <div className="flex items-center justify-between mb-2">
@@ -1785,6 +1998,49 @@ export default function APIPageClient({ machineId }) {
             {editCombosAll && <p className="text-xs text-text-muted">This key can access all combos.</p>}
           </div>
 
+          {/* Limits */}
+          <div>
+            <label className="text-sm font-medium mb-2 block">Usage Limits (leave blank for unlimited)</label>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="text-xs text-text-muted">Expiration</label>
+                <Input type="datetime-local" value={editExpiresAt} onChange={(e) => setEditExpiresAt(e.target.value)} />
+              </div>
+              <div>
+                <label className="text-xs text-text-muted">Max tokens / request</label>
+                <Input type="number" min="0" value={editMaxTokens} onChange={(e) => setEditMaxTokens(e.target.value)} placeholder="∞" />
+              </div>
+              <div>
+                <label className="text-xs text-text-muted">Max tokens / day</label>
+                <Input type="number" min="0" value={editMaxTokensDaily} onChange={(e) => setEditMaxTokensDaily(e.target.value)} placeholder="∞" />
+              </div>
+              <div>
+                <label className="text-xs text-text-muted">Requests / minute</label>
+                <Input type="number" min="0" value={editRpm} onChange={(e) => setEditRpm(e.target.value)} placeholder="∞" />
+              </div>
+              <div>
+                <label className="text-xs text-text-muted">Requests / hour</label>
+                <Input type="number" min="0" value={editRph} onChange={(e) => setEditRph(e.target.value)} placeholder="∞" />
+              </div>
+              <div>
+                <label className="text-xs text-text-muted">Requests / day</label>
+                <Input type="number" min="0" value={editRpd} onChange={(e) => setEditRpd(e.target.value)} placeholder="∞" />
+              </div>
+              <div>
+                <label className="text-xs text-text-muted">Tokens / 5 hours</label>
+                <Input type="number" min="0" value={editTokens5h} onChange={(e) => setEditTokens5h(e.target.value)} placeholder="∞" />
+              </div>
+              <div>
+                <label className="text-xs text-text-muted">Tokens / week</label>
+                <Input type="number" min="0" value={editTokensWeekly} onChange={(e) => setEditTokensWeekly(e.target.value)} placeholder="∞" />
+              </div>
+              <div>
+                <label className="text-xs text-text-muted">Tokens / month</label>
+                <Input type="number" min="0" value={editTokensMonthly} onChange={(e) => setEditTokensMonthly(e.target.value)} placeholder="∞" />
+              </div>
+            </div>
+          </div>
+
           {/* ACL info */}
           <div className="text-xs text-text-muted bg-surface-2 rounded-lg p-3 border border-border-subtle">
             <p className="font-medium mb-1">How it works:</p>
@@ -1792,6 +2048,7 @@ export default function APIPageClient({ machineId }) {
               <li><strong>All allowed</strong> = unrestricted (default). No ACL filtering.</li>
               <li><strong>Unchecked + empty</strong> = deny everything of that type.</li>
               <li><strong>Checked items</strong> = only those items are accessible.</li>
+              <li><strong>Usage limits</strong> = leave blank to disable. Applies to requests made with this key.</li>
             </ul>
           </div>
 
@@ -1801,7 +2058,7 @@ export default function APIPageClient({ machineId }) {
               Cancel
             </Button>
             <Button onClick={handleSaveEditKey} fullWidth disabled={editSaving}>
-              {editSaving ? "Saving..." : "Save ACL"}
+              {editSaving ? "Saving..." : "Save"}
             </Button>
           </div>
         </div>

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -369,12 +369,19 @@ export default function ProviderDetailPage() {
       const settingsRes = await fetch("/api/settings", { cache: "no-store" });
       const settingsData = settingsRes.ok ? await settingsRes.json() : {};
       const current = settingsData.providerStrategies || {};
+      const existingOverride = current[providerId] || {};
 
-      // Build override: null strategy means remove override, use global
-      const override = {};
-      if (strategy) override.fallbackStrategy = strategy;
+      // Build override: merge with existing override to preserve proxy settings
+      const override = { ...existingOverride };
+      if (strategy) {
+        override.fallbackStrategy = strategy;
+      } else {
+        delete override.fallbackStrategy;
+      }
       if (strategy === "round-robin" && stickyLimit !== "") {
         override.stickyRoundRobinLimit = Number(stickyLimit) || 3;
+      } else {
+        delete override.stickyRoundRobinLimit;
       }
 
       const updated = { ...current };
@@ -1415,9 +1422,11 @@ export default function ProviderDetailPage() {
 
       {/* Connections */}
       {isFreeNoAuth ? (
-        <NoAuthProxyCard providerId={providerId} />
+        <NoAuthProxyCard providerId={providerId} isFreeNoAuth={true} />
       ) : (
-        <Card>
+        <div className="flex flex-col gap-6">
+          <NoAuthProxyCard providerId={providerId} isFreeNoAuth={false} />
+          <Card>
           <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <h2 className="text-lg font-semibold">Connections</h2>
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
@@ -1630,6 +1639,7 @@ export default function ProviderDetailPage() {
             </>
           )}
         </Card>
+        </div>
       )}
 
       {/* Models */}

--- a/src/lib/db/repos/apiKeyUsageRepo.js
+++ b/src/lib/db/repos/apiKeyUsageRepo.js
@@ -1,0 +1,274 @@
+import { getAdapter } from "../driver.js";
+
+// In-memory rolling counters. We intentionally keep these in process memory
+// (not the DB) to avoid write amplification on every request and because
+// limit enforcement is best-effort across restarts (a restart resets counters).
+// For stricter accounting, callers can persist usage via usageRepo after the fact.
+
+if (!global._apiKeyCounters) {
+  global._apiKeyCounters = {
+    rpm: new Map(),      // keyId -> { ts: minuteTimestamp, count }
+    rph: new Map(),      // keyId -> { ts: hourTimestamp, count }
+    rpd: new Map(),      // keyId -> { dateKey, count }
+    tokens5h: new Map(), // keyId -> [{ ts, tokens }]
+    tokensDaily: new Map(),// keyId -> { dateKey, tokens }
+    tokensWeekly: new Map(), // keyId -> { weekKey, tokens }
+    tokensMonthly: new Map(),// keyId -> { monthKey, tokens }
+  };
+}
+const counters = global._apiKeyCounters;
+
+function getMinuteTs() {
+  return Math.floor(Date.now() / 60000);
+}
+function getHourTs() {
+  return Math.floor(Date.now() / 3600000);
+}
+function getDateKey() {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+function getWeekKey() {
+  const d = new Date();
+  const start = new Date(d);
+  start.setHours(0, 0, 0, 0);
+  start.setDate(d.getDate() - d.getDay()); // Sunday-based week
+  return `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, "0")}-${String(start.getDate()).padStart(2, "0")}`;
+}
+function getMonthKey() {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+}
+
+function getRollingTokenCount(map, keyId, windowMs) {
+  const now = Date.now();
+  const entries = map.get(keyId) || [];
+  const fresh = entries.filter((e) => now - e.ts <= windowMs);
+  if (fresh.length !== entries.length) map.set(keyId, fresh);
+  return fresh.reduce((sum, e) => sum + e.tokens, 0);
+}
+
+function bumpCounter(map, keyId, bucketKey, amount = 1) {
+  let entry = map.get(keyId);
+  if (!entry || entry.key !== bucketKey) {
+    entry = { key: bucketKey, count: 0 };
+    map.set(keyId, entry);
+  }
+  entry.count += amount;
+  return entry.count;
+}
+
+
+function getBucketEntry(map, keyId, key) {
+  const entry = map.get(keyId);
+  if (!entry || entry.key !== key) return null;
+  return entry;
+}
+
+function buildMetric(limit, used, label, unit = "") {
+  const hasLimit = limit !== null && limit !== undefined;
+  const safeUsed = Math.max(0, Number(used) || 0);
+  const safeLimit = hasLimit ? Math.max(0, Number(limit) || 0) : null;
+  const percent = hasLimit && safeLimit > 0 ? Math.min(999, Math.round((safeUsed / safeLimit) * 100)) : null;
+  return {
+    label,
+    unit,
+    limit: safeLimit,
+    used: safeUsed,
+    remaining: hasLimit ? Math.max(0, safeLimit - safeUsed) : null,
+    percent,
+    status: !hasLimit ? "unlimited" : percent >= 100 ? "blocked" : percent >= 90 ? "danger" : percent >= 70 ? "warning" : "ok",
+  };
+}
+
+function getExpiryStatus(expiresAt) {
+  if (!expiresAt) return { label: "Expiry", status: "unlimited", expiresAt: null, msRemaining: null };
+  const ts = new Date(expiresAt).getTime();
+  if (!Number.isFinite(ts)) return { label: "Expiry", status: "unknown", expiresAt, msRemaining: null };
+  const msRemaining = ts - Date.now();
+  return {
+    label: "Expiry",
+    status: msRemaining <= 0 ? "blocked" : msRemaining <= 24 * 3600000 ? "danger" : msRemaining <= 7 * 24 * 3600000 ? "warning" : "ok",
+    expiresAt,
+    msRemaining,
+  };
+}
+
+function bumpTokens(map, keyId, amount) {
+  let entries = map.get(keyId);
+  if (!entries) {
+    entries = [];
+    map.set(keyId, entries);
+  }
+  entries.push({ ts: Date.now(), tokens: amount });
+}
+
+/**
+ * Check per-key limits BEFORE processing a request.
+ * @param {object} apiKeyInfo - key row from apiKeysRepo
+ * @param {number} requestedTokens - estimated tokens for this request (0 if unknown)
+ * @returns {{ allowed: boolean, reason?: string, retryAfterMs?: number }}
+ */
+export function checkApiKeyLimits(apiKeyInfo, requestedTokens = 0) {
+  if (!apiKeyInfo) return { allowed: true };
+  const keyId = apiKeyInfo.id;
+  const tokens = Math.max(0, Number(requestedTokens) || 0);
+
+  // RPM
+  const rpmLimit = apiKeyInfo.rpm;
+  if (rpmLimit != null) {
+    const minute = getMinuteTs();
+    const current = bumpCounter(counters.rpm, keyId, minute, 0);
+    if (current + 1 > rpmLimit) {
+      return { allowed: false, reason: `Rate limit exceeded: ${rpmLimit} requests per minute`, retryAfterMs: (minute + 1) * 60000 - Date.now() };
+    }
+  }
+
+  // RPH
+  const rphLimit = apiKeyInfo.rph;
+  if (rphLimit != null) {
+    const hour = getHourTs();
+    const current = bumpCounter(counters.rph, keyId, hour, 0);
+    if (current + 1 > rphLimit) {
+      return { allowed: false, reason: `Rate limit exceeded: ${rphLimit} requests per hour`, retryAfterMs: (hour + 1) * 3600000 - Date.now() };
+    }
+  }
+
+  // RPD
+  const rpdLimit = apiKeyInfo.rpd;
+  if (rpdLimit != null) {
+    const date = getDateKey();
+    const current = bumpCounter(counters.rpd, keyId, date, 0);
+    if (current + 1 > rpdLimit) {
+      return { allowed: false, reason: `Rate limit exceeded: ${rpdLimit} requests per day`, retryAfterMs: 86400000 - (Date.now() % 86400000) };
+    }
+  }
+
+  // Max tokens per request
+  if (apiKeyInfo.maxTokens != null && tokens > apiKeyInfo.maxTokens) {
+    return { allowed: false, reason: `Token limit exceeded: max ${apiKeyInfo.maxTokens} tokens per request` };
+  }
+
+  // Daily tokens
+  if (apiKeyInfo.maxTokensDaily != null) {
+    const date = getDateKey();
+    const current = counters.tokensDaily.get(keyId);
+    const used = current?.key === date ? current.tokens : 0;
+    if (used + tokens > apiKeyInfo.maxTokensDaily) {
+      return { allowed: false, reason: `Daily token limit exceeded: ${apiKeyInfo.maxTokensDaily}` };
+    }
+  }
+
+  // 5-hour rolling tokens
+  if (apiKeyInfo.tokens5h != null) {
+    const used = getRollingTokenCount(counters.tokens5h, keyId, 5 * 3600000);
+    if (used + tokens > apiKeyInfo.tokens5h) {
+      return { allowed: false, reason: `5-hour token window exceeded: ${apiKeyInfo.tokens5h}` };
+    }
+  }
+
+  // Weekly tokens
+  if (apiKeyInfo.tokensWeekly != null) {
+    const week = getWeekKey();
+    const current = counters.tokensWeekly.get(keyId);
+    const used = current?.key === week ? current.tokens : 0;
+    if (used + tokens > apiKeyInfo.tokensWeekly) {
+      return { allowed: false, reason: `Weekly token limit exceeded: ${apiKeyInfo.tokensWeekly}` };
+    }
+  }
+
+  // Monthly tokens
+  if (apiKeyInfo.tokensMonthly != null) {
+    const month = getMonthKey();
+    const current = counters.tokensMonthly.get(keyId);
+    const used = current?.key === month ? current.tokens : 0;
+    if (used + tokens > apiKeyInfo.tokensMonthly) {
+      return { allowed: false, reason: `Monthly token limit exceeded: ${apiKeyInfo.tokensMonthly}` };
+    }
+  }
+
+  return { allowed: true };
+}
+
+/**
+ * Record request usage against a key's counters.
+ * @param {object} apiKeyInfo
+ * @param {number} tokensUsed - total tokens consumed (prompt + completion)
+ */
+export function recordApiKeyUsage(apiKeyInfo, tokensUsed = 0) {
+  if (!apiKeyInfo) return;
+  const keyId = apiKeyInfo.id;
+  const tokens = Math.max(0, Number(tokensUsed) || 0);
+
+  bumpCounter(counters.rpm, keyId, getMinuteTs(), 1);
+  bumpCounter(counters.rph, keyId, getHourTs(), 1);
+  bumpCounter(counters.rpd, keyId, getDateKey(), 1);
+
+  if (tokens > 0) {
+    bumpTokens(counters.tokens5h, keyId, tokens);
+
+    const date = getDateKey();
+    const daily = counters.tokensDaily.get(keyId);
+    if (!daily || daily.key !== date) {
+      counters.tokensDaily.set(keyId, { key: date, tokens });
+    } else {
+      daily.tokens += tokens;
+    }
+
+    const week = getWeekKey();
+    const weekly = counters.tokensWeekly.get(keyId);
+    if (!weekly || weekly.key !== week) {
+      counters.tokensWeekly.set(keyId, { key: week, tokens });
+    } else {
+      weekly.tokens += tokens;
+    }
+
+    const month = getMonthKey();
+    const monthly = counters.tokensMonthly.get(keyId);
+    if (!monthly || monthly.key !== month) {
+      counters.tokensMonthly.set(keyId, { key: month, tokens });
+    } else {
+      monthly.tokens += tokens;
+    }
+  }
+}
+
+/**
+ * Get current usage snapshot for a key (for dashboard display).
+ * @param {object} apiKeyInfo
+ */
+export function getApiKeyUsageSnapshot(apiKeyInfo) {
+  if (!apiKeyInfo) return null;
+  const keyId = apiKeyInfo.id;
+  const minute = getMinuteTs();
+  const hour = getHourTs();
+  const date = getDateKey();
+  const week = getWeekKey();
+  const month = getMonthKey();
+  const snapshot = {
+    rpm: buildMetric(apiKeyInfo.rpm, getBucketEntry(counters.rpm, keyId, minute)?.count || 0, "Requests / minute", "req"),
+    rph: buildMetric(apiKeyInfo.rph, getBucketEntry(counters.rph, keyId, hour)?.count || 0, "Requests / hour", "req"),
+    rpd: buildMetric(apiKeyInfo.rpd, getBucketEntry(counters.rpd, keyId, date)?.count || 0, "Requests / day", "req"),
+    tokens5h: buildMetric(apiKeyInfo.tokens5h, getRollingTokenCount(counters.tokens5h, keyId, 5 * 3600000), "Tokens / 5h", "tok"),
+    maxTokens: buildMetric(apiKeyInfo.maxTokens, 0, "Max tokens / request", "tok"),
+    maxTokensDaily: buildMetric(apiKeyInfo.maxTokensDaily, getBucketEntry(counters.tokensDaily, keyId, date)?.tokens || 0, "Tokens / day", "tok"),
+    tokensWeekly: buildMetric(apiKeyInfo.tokensWeekly, getBucketEntry(counters.tokensWeekly, keyId, week)?.tokens || 0, "Tokens / week", "tok"),
+    tokensMonthly: buildMetric(apiKeyInfo.tokensMonthly, getBucketEntry(counters.tokensMonthly, keyId, month)?.tokens || 0, "Tokens / month", "tok"),
+    expiry: getExpiryStatus(apiKeyInfo.expiresAt),
+  };
+  const statuses = Object.values(snapshot).map((m) => m?.status).filter(Boolean);
+  const status = apiKeyInfo.isActive === false
+    ? "paused"
+    : statuses.includes("blocked")
+      ? "blocked"
+      : statuses.includes("danger")
+        ? "danger"
+        : statuses.includes("warning")
+          ? "warning"
+          : "ok";
+  return {
+    status,
+    checkedAt: new Date().toISOString(),
+    metrics: snapshot,
+  };
+}

--- a/src/lib/network/connectionProxy.js
+++ b/src/lib/network/connectionProxy.js
@@ -186,3 +186,54 @@ export function getProxyHash(providerSpecificData = {}) {
   if (poolId) return `pool-${djb2(poolId)}`;
   return "direct";
 }
+
+// In-memory counters for round-robin / fill-first proxy pool rotation.
+// Keyed by `${providerId}:${strategy}:${poolIds}` so different providers,
+// strategies, and selected pool subsets keep independent cursors.
+const _poolCursors = new Map();
+
+function normalizeTargetPoolIds(targetProxyPoolIds) {
+  if (!Array.isArray(targetProxyPoolIds)) return [];
+  return [...new Set(targetProxyPoolIds.map(normalizeString).filter(Boolean))];
+}
+
+export function filterTargetProxyPoolIds(poolIds, targetProxyPoolIds = []) {
+  if (!Array.isArray(poolIds) || poolIds.length === 0) return [];
+  const targets = normalizeTargetPoolIds(targetProxyPoolIds);
+  if (targets.length === 0) return poolIds;
+  const allowed = new Set(targets);
+  return poolIds.filter((id) => allowed.has(id));
+}
+
+/**
+ * Pick a proxy pool id from active pool ids using the configured strategy.
+ * Empty targetProxyPoolIds means all active pools. Non-empty targets filter the
+ * rotation subset; if every target is inactive/missing, returns null so callers
+ * can fall back safely instead of silently using an unselected pool.
+ *
+ * @param {string[]} poolIds active proxy pool ids with a proxyUrl
+ * @param {string} strategy rotation strategy from providerStrategies override
+ * @param {string} providerId provider id for per-provider cursor isolation
+ * @param {string[]} targetProxyPoolIds optional selected subset
+ * @returns {string|null} chosen pool id, or null when pool/subset is empty
+ */
+export function pickProxyPoolId(poolIds, strategy, providerId = "", targetProxyPoolIds = []) {
+  const eligiblePoolIds = filterTargetProxyPoolIds(poolIds, targetProxyPoolIds);
+  if (eligiblePoolIds.length === 0) return null;
+  const strat = String(strategy || "").toLowerCase();
+
+  if (strat === "fill-first") return eligiblePoolIds[0];
+
+  if (strat === "round-robin") {
+    const key = `${providerId}:${strat}:${eligiblePoolIds.join(",")}`;
+    const idx = (_poolCursors.get(key) ?? 0) % eligiblePoolIds.length;
+    _poolCursors.set(key, (idx + 1) % eligiblePoolIds.length);
+    return eligiblePoolIds[idx];
+  }
+
+  if (strat === "random") {
+    return eligiblePoolIds[Math.floor(Math.random() * eligiblePoolIds.length)];
+  }
+
+  return null;
+}

--- a/src/shared/components/NoAuthProxyCard.js
+++ b/src/shared/components/NoAuthProxyCard.js
@@ -7,9 +7,11 @@ import Badge from "./Badge";
 
 const NONE_PROXY_POOL_VALUE = "__none__";
 
-export default function NoAuthProxyCard({ providerId }) {
+export default function NoAuthProxyCard({ providerId, isFreeNoAuth = true }) {
   const [proxyPools, setProxyPools] = useState([]);
   const [proxyPoolId, setProxyPoolId] = useState(NONE_PROXY_POOL_VALUE);
+  const [rotateStrategy, setRotateStrategy] = useState("none");
+  const [targetProxyPoolIds, setTargetProxyPoolIds] = useState([]);
   const [saving, setSaving] = useState(false);
   const [savedFlash, setSavedFlash] = useState(false);
 
@@ -23,23 +25,47 @@ export default function NoAuthProxyCard({ providerId }) {
       setProxyPools(poolData.proxyPools || []);
       const override = (settingsData.providerStrategies || {})[providerId] || {};
       setProxyPoolId(override.proxyPoolId || NONE_PROXY_POOL_VALUE);
+      setRotateStrategy(override.rotateStrategy || "none");
+      setTargetProxyPoolIds(Array.isArray(override.targetProxyPoolIds) ? override.targetProxyPoolIds : []);
     }).catch(() => {});
     return () => controller.abort();
   }, [providerId]);
 
-  const handleChange = async (newValue) => {
-    setProxyPoolId(newValue);
+  const handleSave = async (updatedFields) => {
     setSaving(true);
     try {
       const res = await fetch("/api/settings", { cache: "no-store" });
       const data = res.ok ? await res.json() : {};
       const current = data.providerStrategies || {};
       const override = { ...(current[providerId] || {}) };
-      if (newValue === NONE_PROXY_POOL_VALUE) delete override.proxyPoolId;
-      else override.proxyPoolId = newValue;
+
+      if ("rotateStrategy" in updatedFields) {
+        if (updatedFields.rotateStrategy === "none") {
+          delete override.rotateStrategy;
+        } else {
+          override.rotateStrategy = updatedFields.rotateStrategy;
+        }
+      }
+      if ("proxyPoolId" in updatedFields) {
+        if (updatedFields.proxyPoolId === NONE_PROXY_POOL_VALUE) {
+          delete override.proxyPoolId;
+        } else {
+          override.proxyPoolId = updatedFields.proxyPoolId;
+        }
+      }
+      if ("targetProxyPoolIds" in updatedFields) {
+        const ids = Array.isArray(updatedFields.targetProxyPoolIds) ? updatedFields.targetProxyPoolIds.filter(Boolean) : [];
+        if (ids.length === 0) delete override.targetProxyPoolIds;
+        else override.targetProxyPoolIds = ids;
+      }
+
       const updated = { ...current };
-      if (Object.keys(override).length === 0) delete updated[providerId];
-      else updated[providerId] = override;
+      if (Object.keys(override).length === 0) {
+        delete updated[providerId];
+      } else {
+        updated[providerId] = override;
+      }
+
       await fetch("/api/settings", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
@@ -48,35 +74,125 @@ export default function NoAuthProxyCard({ providerId }) {
       setSavedFlash(true);
       setTimeout(() => setSavedFlash(false), 1500);
     } catch (e) {
-      console.log("Save proxyPoolId error:", e);
+      console.log("Save proxy override error:", e);
     } finally {
       setSaving(false);
     }
+  };
+
+  const handleStrategyChange = (newVal) => {
+    setRotateStrategy(newVal);
+    handleSave({ rotateStrategy: newVal });
+  };
+
+  const handlePoolChange = (newVal) => {
+    setProxyPoolId(newVal);
+    handleSave({ proxyPoolId: newVal });
+  };
+
+  const toggleTargetPool = (poolId) => {
+    const next = targetProxyPoolIds.includes(poolId)
+      ? targetProxyPoolIds.filter((id) => id !== poolId)
+      : [...targetProxyPoolIds, poolId];
+    setTargetProxyPoolIds(next);
+    handleSave({ targetProxyPoolIds: next });
   };
 
   return (
     <Card>
       <div className="flex items-center gap-3 mb-4">
         <div className="inline-flex items-center justify-center w-10 h-10 rounded-full bg-green-500/10 text-green-500">
-          <span className="material-symbols-outlined text-[20px]">lock_open</span>
+          <span className="material-symbols-outlined text-[20px]">lan</span>
         </div>
         <div className="flex-1">
-          <p className="text-sm font-medium">No authentication required</p>
-          <p className="text-xs text-text-muted">This provider is ready to use. Optionally route requests through a proxy pool to bypass IP-based limits.</p>
+          <p className="text-sm font-medium">Proxy Routing & Strategy</p>
+          <p className="text-xs text-text-muted">
+            Configure how traffic for this provider is routed through proxy pools.
+          </p>
         </div>
         {savedFlash && <Badge variant="success" size="sm">Saved</Badge>}
       </div>
-      <Select
-        label="Proxy Pool"
-        value={proxyPoolId}
-        onChange={(e) => handleChange(e.target.value)}
-        disabled={saving}
-        options={[
-          { value: NONE_PROXY_POOL_VALUE, label: "None (direct)" },
-          ...proxyPools.map((pool) => ({ value: pool.id, label: pool.name })),
-        ]}
-      />
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <Select
+          label="Proxy Strategy"
+          value={rotateStrategy}
+          onChange={(e) => handleStrategyChange(e.target.value)}
+          disabled={saving}
+          options={[
+            { value: "none", label: "None (Direct / Static)" },
+            { value: "round-robin", label: "Round-Robin (Rotate active pools)" },
+            { value: "random", label: "Random (Rotate active pools)" },
+          ]}
+        />
+
+        {rotateStrategy === "none" ? (
+          isFreeNoAuth ? (
+            <Select
+              label="Static Proxy Pool"
+              value={proxyPoolId}
+              onChange={(e) => handlePoolChange(e.target.value)}
+              disabled={saving}
+              options={[
+                { value: NONE_PROXY_POOL_VALUE, label: "None (direct)" },
+                ...proxyPools.map((pool) => ({ value: pool.id, label: pool.name })),
+              ]}
+            />
+          ) : (
+            <div className="flex flex-col justify-end pb-1.5">
+              <span className="text-xs text-text-muted italic">
+                Using connection-level proxy settings. Select specific proxies on connections below or click "Apply Proxy".
+              </span>
+            </div>
+          )
+        ) : (
+          <div className="flex flex-col justify-end pb-1.5">
+            <span className="text-xs text-brand-500 font-medium">
+              🔄 Dynamic Rotation active. Individual connection proxy settings will be bypassed.
+            </span>
+          </div>
+        )}
+      </div>
+
+      {rotateStrategy !== "none" && (
+        <div className="mt-4 rounded-xl border border-border/60 bg-surface/40 p-4">
+          <div className="flex items-center justify-between gap-3 mb-3">
+            <div>
+              <p className="text-sm font-medium">Rotation proxy pool subset</p>
+              <p className="text-xs text-text-muted">
+                Select which active pools are eligible for {rotateStrategy}. Leave empty to use all active pools.
+              </p>
+            </div>
+            <Badge variant="secondary" size="sm">
+              {targetProxyPoolIds.length || proxyPools.length} / {proxyPools.length || 0} pools
+            </Badge>
+          </div>
+          {proxyPools.length === 0 ? (
+            <p className="text-xs text-warning">No active proxy pools with URLs found.</p>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              {proxyPools.map((pool) => {
+                const checked = targetProxyPoolIds.includes(pool.id);
+                return (
+                  <label
+                    key={pool.id}
+                    className={`flex items-center gap-3 rounded-lg border px-3 py-2 text-sm cursor-pointer transition-colors ${checked ? "border-primary/60 bg-primary/10" : "border-border/50 hover:bg-surface-2"}`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      disabled={saving}
+                      onChange={() => toggleTargetPool(pool.id)}
+                    />
+                    <span className="min-w-0 flex-1 truncate">{pool.name || pool.id}</span>
+                    <span className="text-[10px] text-text-muted font-mono">{pool.id.slice(0, 8)}</span>
+                  </label>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
     </Card>
   );
 }
-

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -55,7 +55,9 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
       if (strategy !== "none") {
         const allPools = await getProxyPools({ isActive: true });
         const poolIds = allPools.filter(p => p.proxyUrl).map(p => p.id);
-        pickedId = pickProxyPoolId(poolIds, strategy, providerId);
+        pickedId = pickProxyPoolId(poolIds, strategy, providerId, override.targetProxyPoolIds);
+        const targetCount = Array.isArray(override.targetProxyPoolIds) ? override.targetProxyPoolIds.length : 0;
+        log.info("PROXY", `${providerId.toUpperCase()} | no-auth ${strategy} | pool=${pickedId || "none"} | targets=${targetCount || "all"}/${poolIds.length}`);
       }
       const resolvedProxy = await resolveConnectionProxyConfig({ proxyPoolId: pickedId || "" });
       return {
@@ -178,7 +180,24 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
       connection = availableConnections[0];
     }
 
-    const resolvedProxy = await resolveConnectionProxyConfig(connection.providerSpecificData || {});
+    // Proxy rotation — override per-connection proxy pool with dynamically selected
+    // pool when the provider has a rotation strategy configured (round-robin/random).
+    const proxyOverride = (settings.providerStrategies || {})[providerId] || {};
+    const proxyStrategy = proxyOverride.rotateStrategy || "none";
+    let rotProxyPoolId = connection.providerSpecificData?.proxyPoolId || null;
+    if (proxyStrategy !== "none") {
+      const allPools = await getProxyPools({ isActive: true });
+      const poolIds = allPools.filter(p => p.proxyUrl).map(p => p.id);
+      if (poolIds.length > 0) {
+        rotProxyPoolId = pickProxyPoolId(poolIds, proxyStrategy, providerId, proxyOverride.targetProxyPoolIds);
+        const targetCount = Array.isArray(proxyOverride.targetProxyPoolIds) ? proxyOverride.targetProxyPoolIds.length : 0;
+        log.info("PROXY", `${providerId.toUpperCase()} | ${model || "any"} | strategy=${proxyStrategy} | conn=${connection.displayName || connection.name || connection.email || connection.id} | pool=${rotProxyPoolId || "none"} | targets=${targetCount || "all"}/${poolIds.length}`);
+      }
+    }
+    const resolvedProxy = await resolveConnectionProxyConfig({
+      ...(connection.providerSpecificData || {}),
+      proxyPoolId: rotProxyPoolId || "",
+    });
 
     return {
       authType: connection.authType,
@@ -389,7 +408,10 @@ export async function isProviderAllowed(apiKeyInfo, providerIdOrAlias) {
   if (!apiKeyInfo) return true;
   const allowed = apiKeyInfo.allowedProviders;
   if (allowed === null || allowed === undefined) return true; // null = all
-  if (!Array.isArray(allowed) || allowed.length === 0) return false; // [] = none
+  if (!Array.isArray(allowed) || allowed.length === 0) {
+    log.warn("AUTH", `Provider "${providerIdOrAlias}" blocked for key ${apiKeyInfo.id?.slice(0, 8)}: allowedProviders is empty`);
+    return false; // [] = none
+  }
   if (allowed.includes(providerIdOrAlias)) return true;
   const alias = getProviderAlias(providerIdOrAlias);
   if (alias !== providerIdOrAlias && allowed.includes(alias)) return true;
@@ -399,6 +421,7 @@ export async function isProviderAllowed(apiKeyInfo, providerIdOrAlias) {
     const prefix = await getNodePrefix(providerIdOrAlias);
     if (prefix && allowed.includes(prefix)) return true;
   }
+  log.warn("AUTH", `Provider "${providerIdOrAlias}" blocked for key ${apiKeyInfo.id?.slice(0, 8)}: allowed=[${allowed.join(", ")}]`);
   return false;
 }
 
@@ -411,8 +434,15 @@ export function isComboAllowed(apiKeyInfo, comboName) {
   const name = comboName.startsWith("combo/") ? comboName.slice(6) : comboName;
   const allowed = apiKeyInfo.allowedCombos;
   if (allowed === null || allowed === undefined) return true;
-  if (!Array.isArray(allowed) || allowed.length === 0) return false;
-  return allowed.includes(name);
+  if (!Array.isArray(allowed) || allowed.length === 0) {
+    log.warn("AUTH", `Combo "${name}" blocked for key ${apiKeyInfo.id?.slice(0, 8)}: allowedCombos is empty`);
+    return false;
+  }
+  const ok = allowed.includes(name);
+  if (!ok) {
+    log.warn("AUTH", `Combo "${name}" blocked for key ${apiKeyInfo.id?.slice(0, 8)}: allowed=[${allowed.join(", ")}]`);
+  }
+  return ok;
 }
 
 /**
@@ -424,7 +454,14 @@ export function isKindAllowed(apiKeyInfo, kind) {
   if (!apiKeyInfo) return true;
   const allowed = apiKeyInfo.allowedKinds;
   if (allowed === null || allowed === undefined) return true; // null = all
-  if (!Array.isArray(allowed) || allowed.length === 0) return false; // [] = none
-  return allowed.includes(kind);
+  if (!Array.isArray(allowed) || allowed.length === 0) {
+    log.warn("AUTH", `Kind "${kind}" blocked for key ${apiKeyInfo.id?.slice(0, 8)}: allowedKinds is empty`);
+    return false; // [] = none
+  }
+  const ok = allowed.includes(kind);
+  if (!ok) {
+    log.warn("AUTH", `Kind "${kind}" blocked for key ${apiKeyInfo.id?.slice(0, 8)}: allowed=[${allowed.join(", ")}]`);
+  }
+  return ok;
 }
 


### PR DESCRIPTION
## Summary

This PR supersedes #67 and #73, combining their features with additional improvements:

### Features

**1. Proxy Rotation with Custom Pool Selection**
- Provider-level rotation strategies: `none`, `fill-first`, `round-robin`, `random`
- **NEW**: Checkbox grid UI to select a subset of active proxy pools for rotation (instead of rotating across all pools globally)
- `pickProxyPoolId()` accepts `targetProxyPoolIds` parameter to filter rotation
- Proxy usage logging: `[PROXY] PROVIDER | model | conn=Name | pool=ID | vercel-relay=URL`
- Virtual connection injection for no-auth free providers (unified proxy resolution pipeline)

**2. API Key Quota Tracker**
- `getApiKeyUsageSnapshot()` returns real-time metrics: rpm, rph, rpd, tokens/5h, tokens/day, tokens/week, tokens/month
- Each metric includes `used`, `limit`, `percent`, and `status` (`ok`/`warning`/`danger`/`blocked`)
- Dashboard card grid with status badges, quota progress bars, and summary stats
- In-memory rolling counters (`apiKeyCounters.js`) to avoid DB write amplification

**3. Tailscale Loading Fix**
- UI no longer stuck in endless loading when `tunnelUrl` is empty
- Login pending state shows warning instead of infinite spinner
- `clearUserAuth()` removed from `finally` block — buttons remain accessible

### Superseded PRs
- **#67** (proxy-rotation-strategy): Basic rotation UI — this PR includes those changes plus custom pool subset selection
- **#73** (api-key-limits): Key limits backend — this PR includes those changes plus the quota tracker UI and usage snapshot

### Files Changed
| File | Changes |
|------|---------|
| `connectionProxy.js` | `pickProxyPoolId` with `targetProxyPoolIds`, `resolveConnectionProxyConfig`, `filterTargetProxyPoolIds` |
| `NoAuthProxyCard.js` | Rotation strategy selector, checkbox grid for pool subset, conditional UI |
| `auth.js` | Proxy pool override, virtual connection injection, API key limit enforcement |
| `EndpointPageClient.js` | API key card grid, quota progress bars, status badges, Tailscale loading fix |
| `apiKeyUsageRepo.js` | `getApiKeyUsageSnapshot`, `buildMetric` helper |
| `providers/[id]/page.js` | Render `NoAuthProxyCard` for all providers |
| `pnpm-lock.yaml` | `duck-duck-scrape` dependency |

## Test Plan
- [x] Docker image builds (`vansrouter:full-merge`)
- [x] Container serves 201 models
- [x] `oc/deepseek-v4-flash-free` chat completion → 200
- [x] Proxy pool logging in container logs
- [x] API key usage snapshot returns correct metrics
- [x] Public domain `https://router.mahdiwafy.my.id/v1/models` → 200
- [x] Tailscale status endpoint returns valid JSON without hanging
