### PR TITLE
feat(usage): Antigravity quota grouping and auto-ping scheduler

### DIFF
--- a/open-sse/services/usage/antigravityWeeklyTracker.js
+++ b/open-sse/services/usage/antigravityWeeklyTracker.js
@@ -1,0 +1,183 @@
+/**
+ * Antigravity Weekly Usage Tracker
+ *
+ * Estimates weekly usage from 7-day rolling request history.
+ * Since the Antigravity REST API only returns 5-hour window metrics
+ * (remainingFraction), we track actual request patterns to approximate
+ * the weekly view shown in the Antigravity Desktop app.
+ *
+ * Buckets (matching official Antigravity 2.0 grouping):
+ *   - Gemini Models: gemini-*, gemini-pro-agent
+ *   - Claude & GPT Models: claude-*, gpt-*
+ *
+ * IMPORTANT: Antigravity quota is measured in REQUESTS (the 5H window is
+ * ~1000 requests), NOT tokens. We count request rows in usageHistory,
+ * not token sums.
+ *
+ * Usage notes:
+ * - This is an ESTIMATE, not an exact server-side quota.
+ * - Weekly total is inferred from the 5H window limit × expected weekly cycles.
+ * - More accurate with longer uptime and consistent request flow.
+ */
+
+import { getAdapter } from "../../../src/lib/db/driver.js";
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+// Map model names to their bucket
+const BUCKET_RULES = [
+  { match: /^gemini-/i, bucket: "gemini_weekly" },
+  { match: /^claude-/i, bucket: "claude_gpt_weekly" },
+  { match: /^gpt-/i, bucket: "claude_gpt_weekly" },
+];
+
+/**
+ * Determine which weekly bucket a model belongs to.
+ * @param {string} modelName
+ * @returns {string|null} Bucket key or null if unknown
+ */
+function resolveBucket(modelName) {
+  if (!modelName) return null;
+  for (const rule of BUCKET_RULES) {
+    if (rule.match.test(modelName)) return rule.bucket;
+  }
+  return null;
+}
+
+/**
+ * Query usageHistory for the last 7 days and compute per-bucket usage.
+ * Counts REQUEST rows (Antigravity quota unit), grouped by model bucket.
+ *
+ * @param {string} connectionId - The Antigravity connection UUID
+ * @returns {Promise<{
+ *   gemini_weekly: { used: number, total: number, resetAt: string|null, remainingPercentage: number, displayName: string },
+ *   claude_gpt_weekly: { used: number, total: number, resetAt: string|null, remainingPercentage: number, displayName: string }
+ * }>}
+ */
+export async function getWeeklyUsage(connectionId) {
+  if (!connectionId) {
+    return buildEmptyResult();
+  }
+
+  try {
+    const db = await getAdapter();
+    const cutoff = new Date(Date.now() - SEVEN_DAYS_MS).toISOString();
+
+    // Fetch request rows for this connection within the last 7 days.
+    // Count rows (requests), skipping error rows to avoid inflating usage.
+    const rows = db.all(
+      `SELECT model, timestamp, status
+       FROM usageHistory
+       WHERE connectionId = ?
+         AND timestamp >= ?
+       ORDER BY timestamp ASC`,
+      [connectionId, cutoff],
+    );
+
+    // Accumulate request counts per bucket + track first-use timestamp per
+    // bucket. Antigravity's weekly window starts counting down from the first
+    // request of that bucket (same principle as the 5H window), so each
+    // bucket gets its own weekly reset = firstUse + 7 days.
+    const bucketRequests = {
+      gemini_weekly: 0,
+      claude_gpt_weekly: 0,
+    };
+    const bucketFirstUse = {
+      gemini_weekly: null,
+      claude_gpt_weekly: null,
+    };
+
+    for (const row of rows) {
+      // Skip error rows — they don't consume quota
+      if (row.status === "error" || row.status === "failed") continue;
+
+      const model = (row.model || "").trim();
+      const bucket = resolveBucket(model);
+      if (!bucket) continue;
+
+      bucketRequests[bucket] += 1;
+      if (!bucketFirstUse[bucket] || row.timestamp < bucketFirstUse[bucket]) {
+        bucketFirstUse[bucket] = row.timestamp;
+      }
+    }
+
+    // Scale to a full 7-day window if we only observed a partial window.
+    // This estimates what usage WOULD look like over the full week.
+    let observedAny = Object.values(bucketRequests).some((v) => v > 0);
+    if (observedAny) {
+      const timestamps = [];
+      for (const bucket of Object.keys(bucketRequests)) {
+        if (bucketFirstUse[bucket]) timestamps.push(bucketFirstUse[bucket]);
+      }
+      const earliest = timestamps.length ? new Date(Math.min(...timestamps.map((t) => new Date(t).getTime()))) : null;
+      const latestTs = timestamps.length ? new Date(Math.max(...timestamps.map((t) => new Date(t).getTime()))) : null;
+      if (earliest && latestTs) {
+        const actualMs = latestTs.getTime() - earliest.getTime();
+        if (actualMs > 0 && actualMs < SEVEN_DAYS_MS) {
+          const scale = SEVEN_DAYS_MS / actualMs;
+          for (const key of Object.keys(bucketRequests)) {
+            bucketRequests[key] = Math.round(bucketRequests[key] * scale);
+          }
+        }
+      }
+    }
+
+    // Estimated weekly total per bucket (requests). The 5H API reports
+    // total=1000 requests per window; the real weekly pool (shown in the
+    // Antigravity app) is smaller than 7× the 5H pool — typically 3-5×.
+    // Use a conservative 4× multiplier = 4000 requests per week.
+    const WEEKLY_ESTIMATED_TOTAL = 4000;
+
+    const result = {};
+
+    for (const [bucketKey, displayName] of [
+      ["gemini_weekly", "Gemini Models"],
+      ["claude_gpt_weekly", "Claude & GPT Models"],
+    ]) {
+      const used = bucketRequests[bucketKey] || 0;
+      const total = WEEKLY_ESTIMATED_TOTAL;
+      const remainingPercentage = total > 0
+        ? Math.max(0, Math.round(((total - used) / total) * 100))
+        : 100;
+
+      // Per-bucket weekly reset: first use of this bucket + 7 days.
+      // If the bucket hasn't been used yet, show a full 7d window from now.
+      const firstUseMs = bucketFirstUse[bucketKey]
+        ? new Date(bucketFirstUse[bucketKey]).getTime()
+        : Date.now();
+      const resetAt = new Date(firstUseMs + SEVEN_DAYS_MS).toISOString();
+
+      result[bucketKey] = {
+        used,
+        total,
+        resetAt,
+        remainingPercentage,
+        unlimited: false,
+        displayName,
+        isWeekly: true, // Flag for UI differentiation
+        estimated: true, // Weekly totals are estimates (7-day request history scaled + 4x multiplier), not provider-reported
+      };
+    }
+
+    return result;
+  } catch (error) {
+    console.error("[Antigravity WeeklyTracker] Error:", error.message);
+    return buildEmptyResult();
+  }
+}
+
+function buildEmptyResult() {
+  const resetAt = new Date(Date.now() + SEVEN_DAYS_MS).toISOString();
+  return {
+    gemini_weekly: {
+      used: 0, total: 4000, resetAt,
+      remainingPercentage: 100, unlimited: false,
+      displayName: "Gemini Models", isWeekly: true, estimated: true,
+    },
+    claude_gpt_weekly: {
+      used: 0, total: 4000, resetAt,
+      remainingPercentage: 100, unlimited: false,
+      displayName: "Claude & GPT Models", isWeekly: true, estimated: true,
+    },
+  };
+}

--- a/src/shared/services/quotaAutoPing.js
+++ b/src/shared/services/quotaAutoPing.js
@@ -4,6 +4,7 @@ import "open-sse/index.js";
 import { getSettings, getProviderConnections, updateProviderConnection } from "@/lib/localDb";
 import { getClaudeUsage } from "open-sse/services/usage/claude.js";
 import { getCodexUsage } from "open-sse/services/usage/codex.js";
+import { getAntigravityUsage } from "open-sse/services/usage/google.js";
 import { getExecutor } from "open-sse/executors/index.js";
 import { CLAUDE_CLI_SPOOF_HEADERS } from "open-sse/providers/shared.js";
 import { proxyAwareFetch } from "open-sse/utils/proxyFetch.js";
@@ -22,6 +23,10 @@ const providerHandlers = {
   codex: {
     getUsage: getCodexUsage,
     sendPing: sendCodexPing,
+  },
+  antigravity: {
+    getUsage: getAntigravityUsage,
+    sendPing: sendAntigravityPing,
   },
 };
 
@@ -263,9 +268,10 @@ export async function runQuotaAutoPingTick(deps = createDefaultDeps(), state = g
   state.running = true;
   try {
     const settings = await deps.getSettings();
+    const handlers = deps.providerHandlers || providerHandlers;
 
     for (const [provider, providerConfig] of Object.entries(C.providers)) {
-      const handler = providerHandlers[provider];
+      const handler = handlers[provider];
       if (!handler) continue;
 
       const enabledMap = settings?.[providerConfig.settingsKey]?.connections || {};
@@ -286,6 +292,37 @@ export async function runQuotaAutoPingTick(deps = createDefaultDeps(), state = g
     console.warn("[AutoPing] tick error:", e.message);
   } finally {
     state.running = false;
+  }
+}
+
+async function sendAntigravityPing(connection, providerConfig, proxyOptions, deps) {
+  const executor = deps.getExecutor("antigravity");
+  const { response } = await executor.execute({
+    model: providerConfig.pingModel,
+    stream: true,
+    credentials: {
+      accessToken: connection.accessToken,
+      connectionId: connection.id,
+      providerSpecificData: connection.providerSpecificData,
+    },
+    proxyOptions,
+    log: console,
+    messages: [
+      {
+        role: "user",
+        content: providerConfig.pingText,
+      },
+    ],
+  });
+
+  const reader = response.body.getReader();
+  try {
+    while (true) {
+      const { done } = await reader.read();
+      if (done) return;
+    }
+  } finally {
+    reader.releaseLock?.();
   }
 }
 

--- a/tests/unit/antigravity-weekly-bucket.test.js
+++ b/tests/unit/antigravity-weekly-bucket.test.js
@@ -1,0 +1,50 @@
+// #82 review notes: bucket classification fixtures (Gemini vs Claude/GPT)
+// and estimated marker on weekly usage.
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  all: vi.fn(),
+}));
+
+vi.mock("../../src/lib/db/driver.js", () => ({
+  getAdapter: vi.fn(async () => ({ all: mocks.all })),
+}));
+
+import { getWeeklyUsage } from "../../open-sse/services/usage/antigravityWeeklyTracker.js";
+
+const isoNow = new Date().toISOString();
+
+describe("antigravity weekly bucket classification", () => {
+  it("classifies gemini-* into gemini_weekly with estimated marker", async () => {
+    mocks.all.mockReturnValue([
+      { model: "gemini-3.6-flash-high", status: "success", timestamp: isoNow },
+      { model: "gemini-3-flash-agent", status: "success", timestamp: isoNow },
+    ]);
+    const result = await getWeeklyUsage("conn-1");
+    expect(result.gemini_weekly.used).toBeGreaterThan(0);
+    expect(result.gemini_weekly.estimated).toBe(true);
+    expect(result.gemini_weekly.isWeekly).toBe(true);
+    expect(result.gemini_weekly.displayName).toBe("Gemini Models");
+  });
+
+  it("classifies claude-* and gpt-* into claude_gpt_weekly", async () => {
+    mocks.all.mockReturnValue([
+      { model: "claude-sonnet-4-6", status: "success", timestamp: isoNow },
+      { model: "gpt-5.5", status: "success", timestamp: isoNow },
+    ]);
+    const result = await getWeeklyUsage("conn-1");
+    expect(result.claude_gpt_weekly.used).toBeGreaterThan(0);
+    expect(result.claude_gpt_weekly.estimated).toBe(true);
+    expect(result.claude_gpt_weekly.displayName).toBe("Claude & GPT Models");
+  });
+
+  it("skips error rows (they don't consume quota)", async () => {
+    mocks.all.mockReturnValue([
+      { model: "gemini-3.6-flash-high", status: "error", timestamp: isoNow },
+      { model: "claude-sonnet-4-6", status: "failed", timestamp: isoNow },
+    ]);
+    const result = await getWeeklyUsage("conn-1");
+    expect(result.gemini_weekly.used).toBe(0);
+    expect(result.claude_gpt_weekly.used).toBe(0);
+  });
+});

--- a/tests/unit/quota-autoping.test.js
+++ b/tests/unit/quota-autoping.test.js
@@ -1,0 +1,100 @@
+// #82 review notes: auto-ping must be explicit opt-in (default off), with
+// cooldown/timeout/retry and duplicate-scheduler protection, and failed or
+// aborted pings must not corrupt quota state.
+import { describe, expect, it, vi } from "vitest";
+import { runQuotaAutoPingTick } from "../../src/shared/services/quotaAutoPing.js";
+import { QUOTA_AUTOPING_CONFIG } from "../../src/shared/constants/config.js";
+
+function makeDeps({ settings, connections = [], usage, pingResult = true, failRefresh = false }) {
+  const conns = connections.map((c) => ({ authType: "oauth", ...c }));
+  const state = { running: false, resetCache: {}, failureCache: {} };
+  const deps = {
+    getSettings: vi.fn(async () => settings),
+    getProviderConnections: vi.fn(async () => conns),
+    updateProviderConnection: vi.fn(async () => {}),
+    resolveConnectionProxyConfig: vi.fn(async () => ({})),
+    refreshAndUpdateCredentials: vi.fn(async (conn) => {
+      if (failRefresh) throw new Error("refresh failed");
+      return { connection: conn };
+    }),
+    proxyAwareFetch: vi.fn(),
+    getExecutor: vi.fn(),
+  };
+  const handler = {
+    getUsage: vi.fn(async () => usage),
+    sendPing: vi.fn(async () => pingResult),
+  };
+  return { deps, state, handler };
+}
+
+describe("runQuotaAutoPingTick (opt-in + safety)", () => {
+  const cfg = QUOTA_AUTOPING_CONFIG.providers.antigravity;
+
+  it("does nothing when no connections are enabled (default off)", async () => {
+    const { deps, state, handler } = makeDeps({
+      settings: { [cfg.settingsKey]: { connections: {} } },
+      connections: [{ id: "c1", providerSpecificData: {} }],
+      usage: { quotas: { [cfg.quotaKey]: { resetAt: new Date(Date.now() - 1000).toISOString(), remaining: 1 } } },
+    });
+    await runQuotaAutoPingTick({ ...deps, providerHandlers: { antigravity: handler } }, state);
+    expect(handler.sendPing).not.toHaveBeenCalled();
+    expect(deps.updateProviderConnection).not.toHaveBeenCalled();
+  });
+
+  it("pings only connections explicitly enabled", async () => {
+    const { deps, state, handler } = makeDeps({
+      settings: { [cfg.settingsKey]: { connections: { c1: true } } },
+      connections: [
+        { id: "c1", providerSpecificData: {} },
+        { id: "c2", providerSpecificData: {} },
+      ],
+      usage: { quotas: { [cfg.quotaKey]: { resetAt: new Date(Date.now() - 1000).toISOString(), remaining: 1 } } },
+    });
+    await runQuotaAutoPingTick({ ...deps, providerHandlers: { antigravity: handler } }, state);
+    expect(handler.sendPing).toHaveBeenCalledTimes(1);
+    // sendPing receives the enabled connection (c1)
+    expect(handler.sendPing.mock.calls[0][0].id).toBe("c1");
+  });
+
+  it("skips when reset window already pinged (duplicate protection)", async () => {
+    const { deps, state, handler } = makeDeps({
+      settings: { [cfg.settingsKey]: { connections: { c1: true } } },
+      connections: [{ id: "c1", lastPingedResetKey: "reset-1", providerSpecificData: {} }],
+      usage: { quotas: { [cfg.quotaKey]: { resetAt: "2026-08-04T00:00:00.000Z", remaining: 1 } } },
+    });
+    // resetAt normalized to minute boundary matches the stored lastPingedResetKey
+    const resetAt = "2026-08-04T00:00:00.000Z";
+    const deps2 = {
+      ...deps,
+      getProviderConnections: vi.fn(async () => [{ id: "c1", lastPingedResetKey: resetAt, providerSpecificData: {} }]),
+    };
+    const usage2 = { quotas: { [cfg.quotaKey]: { resetAt, remaining: 1 } } };
+    const handler2 = { ...handler, getUsage: vi.fn(async () => usage2) };
+    await runQuotaAutoPingTick({ ...deps2, providerHandlers: { antigravity: handler2 } }, state);
+    expect(handler2.sendPing).not.toHaveBeenCalled();
+  });
+
+  it("failed ping does not corrupt state: no lastPingedResetAt write, failure cooldown set", async () => {
+    const { deps, state, handler } = makeDeps({
+      settings: { [cfg.settingsKey]: { connections: { c1: true } } },
+      connections: [{ id: "c1", providerSpecificData: {} }],
+      usage: { quotas: { [cfg.quotaKey]: { resetAt: new Date(Date.now() - 1000).toISOString(), remaining: 1 } } },
+      pingResult: false,
+    });
+    await runQuotaAutoPingTick({ ...deps, providerHandlers: { antigravity: handler } }, state);
+    expect(deps.updateProviderConnection).not.toHaveBeenCalled();
+    expect(state.failureCache["antigravity:c1"]).toBeTypeOf("number");
+  });
+
+  it("refresh failure is fail-soft: sets cooldown, does not ping", async () => {
+    const { deps, state, handler } = makeDeps({
+      settings: { [cfg.settingsKey]: { connections: { c1: true } } },
+      connections: [{ id: "c1", providerSpecificData: {} }],
+      usage: { quotas: { [cfg.quotaKey]: { resetAt: new Date(Date.now() - 1000).toISOString(), remaining: 1 } } },
+      failRefresh: true,
+    });
+    await runQuotaAutoPingTick({ ...deps, providerHandlers: { antigravity: handler } }, state);
+    expect(handler.sendPing).not.toHaveBeenCalled();
+    expect(state.failureCache["antigravity:c1"]).toBeTypeOf("number");
+  });
+});


### PR DESCRIPTION
## Summary
Refactor Antigravity usage parsing to group models into quotas buckets (Gemini vs Claude/GPT) as enforced by the upstream API, and add an Auto-Ping scheduler to keep windows warm.

### Changes
1. **Quota Grouping**: `open-sse/services/usage/google.js` no longer loops through 10 repeated models. It now parses the response and outputs two specific buckets:
   - `gemini_bucket`: Represents the shared limits for all Gemini models.
   - `claude_gpt_bucket`: Represents the shared limits for Claude and GPT-OSS models.
   - This directly fixes the UI on `/dashboard/usage` to show 2 progress bars instead of 10 repeated/misleading rows.

2. **Auto Ping Scheduler**: Added `antigravity` to the Auto Ping scheduler (`src/shared/services/quotaAutoPing.js` & `config.js`).
   - Dashboard users can now toggle a lightning bolt ⚡ to auto-ping their Antigravity connection when the 5-hour window resets.
   - The ping sends a tiny 1-token "hi" request using `gemini-3.5-flash-low` to immediately restart the quota window.

### Verification
- `npm run lint:undef` — clean
- Rebuilt Docker image successfully.
- Verified dashboard now shows exactly 2 buckets (Gemini & Claude/GPT) with correct remaining percentages.