### PR TITLE
feat(tunnel): add named tunnel support for custom domains

### DIFF
--- a/src/lib/tunnel/cloudflare/cloudflared.js
+++ b/src/lib/tunnel/cloudflare/cloudflared.js
@@ -10,6 +10,7 @@ import {
   NAMED_TUNNEL_HOSTNAME,
   NAMED_TUNNEL_CRED_FILE,
   NAMED_TUNNEL_ID,
+  validateNamedTunnelConfig,
 } from "./config.js";
 
 const BIN_DIR = path.join(DATA_DIR, "bin");
@@ -280,6 +281,17 @@ async function spawnCloudflared(tunnelToken) {
  * Resolves when cloudflared reports "Registered tunnel connection".
  */
 export async function spawnNamedTunnel(localPort, hostname) {
+  // Validate env config BEFORE creating temp dirs / writing config.
+  const validation = validateNamedTunnelConfig({
+    hostname,
+    token: NAMED_TUNNEL_TOKEN,
+    credFile: NAMED_TUNNEL_CRED_FILE,
+    id: NAMED_TUNNEL_ID,
+  });
+  if (!validation.ok) {
+    throw new Error(`Named tunnel config invalid: ${validation.errors.join("; ")}`);
+  }
+
   const binaryPath = await ensureCloudflared();
 
   const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "cloudflared-named-"));

--- a/src/lib/tunnel/cloudflare/cloudflared.js
+++ b/src/lib/tunnel/cloudflare/cloudflared.js
@@ -5,6 +5,12 @@ import os from "os";
 import { execSync, spawn } from "child_process";
 import { savePid, loadPid, clearPid } from "./pid.js";
 import { DATA_DIR } from "@/lib/dataDir.js";
+import {
+  NAMED_TUNNEL_TOKEN,
+  NAMED_TUNNEL_HOSTNAME,
+  NAMED_TUNNEL_CRED_FILE,
+  NAMED_TUNNEL_ID,
+} from "./config.js";
 
 const BIN_DIR = path.join(DATA_DIR, "bin");
 const BINARY_NAME = "cloudflared";
@@ -269,6 +275,161 @@ async function spawnCloudflared(tunnelToken) {
 }
 
 /**
+ * Spawn a NAMED tunnel (custom domain) using either a tunnel token or credentials file.
+ * Requires DNS CNAME <hostname> → <tunnel-id>.cfargotunnel.com (proxied).
+ * Resolves when cloudflared reports "Registered tunnel connection".
+ */
+export async function spawnNamedTunnel(localPort, hostname) {
+  const binaryPath = await ensureCloudflared();
+
+  const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "cloudflared-named-"));
+  const configPath = path.join(configDir, "config.yml");
+
+  // Determine auth mode
+  const useToken = !!NAMED_TUNNEL_TOKEN;
+  const credFile = useToken ? "" : NAMED_TUNNEL_CRED_FILE;
+  const tunnelId = useToken ? NAMED_TUNNEL_TOKEN : (NAMED_TUNNEL_ID || readTunnelIdFromCreds(credFile));
+
+  if (!useToken && !credFile) {
+    throw new Error("Named tunnel requires either TUNNEL_TOKEN or TUNNEL_CRED_FILE (+ TUNNEL_ID)");
+  }
+
+  // Write config file based on auth mode
+  if (useToken) {
+    // Token-based: tunnel = token, no credentials-file needed
+    fs.writeFileSync(
+      configPath,
+      `tunnel: ${NAMED_TUNNEL_TOKEN}\ningress:\n  - hostname: ${hostname}\n    service: http://127.0.0.1:${localPort}\n  - service: http_status:404\n`,
+      "utf8"
+    );
+  } else {
+    // Credentials file mode: tunnel = UUID, credentials-file = path to .json
+    fs.writeFileSync(
+      configPath,
+      `tunnel: ${tunnelId}\ncredentials-file: ${credFile}\ningress:\n  - hostname: ${hostname}\n    service: http://127.0.0.1:${localPort}\n  - service: http_status:404\n`,
+      "utf8"
+    );
+  }
+
+  let isCleaned = false;
+  const cleanup = () => {
+    if (isCleaned) return;
+    isCleaned = true;
+    try {
+      fs.rmSync(configDir, { recursive: true, force: true });
+    } catch (e) { /* ignore */ }
+  };
+
+  const requestedProtocol = String(process.env.TUNNEL_TRANSPORT_PROTOCOL || process.env.CLOUDFLARED_PROTOCOL || DEFAULT_QUICK_TUNNEL_PROTOCOL).trim().toLowerCase();
+  const tunnelProtocol = QUICK_TUNNEL_PROTOCOLS.has(requestedProtocol) ? requestedProtocol : DEFAULT_QUICK_TUNNEL_PROTOCOL;
+
+  // killCloudflared() (called before enable) sets intentionalKill=true to suppress
+  // exit noise from the OLD process. Reset it before spawning the NEW process so a
+  // genuine startup failure surfaces its real error instead of "cloudflared killed".
+  intentionalKill = false;
+
+  // `tunnel run` does NOT support --retries (that flag is for quick tunnels).
+    // Named tunnels reconnect to the edge automatically; the watchdog handles
+    // process-level recovery.
+    // NOTE: --config and --no-autoupdate must come BEFORE the `run` subcommand
+    // (cloudflared parses them as tunnel command options, not run subcommand options).
+    const args = useToken
+      ? ["tunnel", "--config", configPath, "--no-autoupdate", "run", "--token", NAMED_TUNNEL_TOKEN]
+      : ["tunnel", "--config", configPath, "--no-autoupdate", "run", tunnelId];
+
+  const child = spawn(binaryPath, args, {
+    detached: false,
+    windowsHide: true,
+    cwd: os.tmpdir(),
+    env: {
+      ...process.env,
+      TUNNEL_TRANSPORT_PROTOCOL: tunnelProtocol,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  cloudflaredProcess = child;
+  savePid(child.pid);
+
+  return new Promise((resolve, reject) => {
+    let resolved = false;
+    let connectionCount = 0;
+    let logTail = "";
+
+    const timeout = setTimeout(() => {
+      if (resolved) return;
+      resolved = true;
+      cleanup();
+      reject(new Error(`Named tunnel connection timed out. Last log: ${logTail.slice(-800) || "(empty)"}`));
+    }, 90000);
+
+    const handleLog = (data) => {
+      const msg = data.toString();
+      logTail = (logTail + msg).slice(-4000);
+      const matches = msg.match(/Registered tunnel connection/g);
+      if (matches) {
+        connectionCount += matches.length;
+        if (!resolved && connectionCount >= 4) {
+          resolved = true;
+          clearTimeout(timeout);
+          cleanup();
+          console.log(`[Tunnel] named tunnel registered (${hostname})`);
+          resolve({ child, tunnelUrl: `https://${hostname}` });
+        }
+      }
+    };
+
+    child.stdout.on("data", handleLog);
+    child.stderr.on("data", handleLog);
+
+    child.on("error", (err) => {
+      if (resolved) return;
+      resolved = true;
+      clearTimeout(timeout);
+      cleanup();
+      reject(err);
+    });
+
+    child.on("exit", (code, signal) => {
+      cloudflaredProcess = null;
+      clearPid();
+      if (intentionalKill) {
+        intentionalKill = false;
+        clearTimeout(timeout);
+        cleanup();
+        if (!resolved) { resolved = true; reject(new Error("cloudflared killed")); }
+        return;
+      }
+      console.log(`[Tunnel] named cloudflared exit code=${code} signal=${signal}`);
+      if (!resolved) {
+        resolved = true;
+        clearTimeout(timeout);
+        cleanup();
+        const tail = logTail.slice(-600).trim() || "(empty)";
+        if (code === 1) {
+          reject(new Error(`cloudflared named tunnel exited (code 1). Common causes: (1) invalid tunnel token/credentials, (2) outbound port 7844 (TCP/UDP) blocked, (3) DNS CNAME for ${hostname} not pointing to the tunnel. Last log: ${tail}`));
+        } else {
+          reject(new Error(`cloudflared exited (code ${code}). Last log: ${tail}`));
+        }
+        return;
+      }
+      if (unexpectedExitHandler) unexpectedExitHandler();
+      cleanup();
+    });
+  });
+}
+
+function readTunnelIdFromCreds(credFile) {
+  try {
+    const content = fs.readFileSync(credFile, "utf8");
+    const json = JSON.parse(content);
+    return json.TunnelID || json.TunnelId || "";
+  } catch {
+    return "";
+  }
+}
+
+/**
  * Spawn cloudflared quick tunnel (no account needed)
  * Returns the generated trycloudflare.com URL
  */
@@ -291,6 +452,11 @@ export async function spawnQuickTunnel(localPort, onUrlUpdate) {
 
   const requestedProtocol = String(process.env.TUNNEL_TRANSPORT_PROTOCOL || process.env.CLOUDFLARED_PROTOCOL || DEFAULT_QUICK_TUNNEL_PROTOCOL).trim().toLowerCase();
   const tunnelProtocol = QUICK_TUNNEL_PROTOCOLS.has(requestedProtocol) ? requestedProtocol : DEFAULT_QUICK_TUNNEL_PROTOCOL;
+
+  // Reset intentionalKill (set by a prior killCloudflared()) before spawning the
+  // new process so startup failures surface their real error (see spawnNamedTunnel).
+  intentionalKill = false;
+
   const child = spawn(binaryPath, ["tunnel", "--url", `http://127.0.0.1:${localPort}`, "--config", configPath, "--no-autoupdate", "--retries", "99"], {
     detached: false,
     windowsHide: true,

--- a/src/lib/tunnel/cloudflare/config.js
+++ b/src/lib/tunnel/cloudflare/config.js
@@ -7,3 +7,23 @@ export const HEALTH_CHECK = {
 };
 
 export const WORKER_URL = process.env.TUNNEL_WORKER_URL || "https://abc-tunnel.us";
+
+// ─── Named tunnel (custom domain) config ────────────────────────────────
+// When configured, enableTunnel() runs a NAMED tunnel instead of the
+// anonymous quick tunnel, exposing the router on the operator's own
+// hostname (e.g. vr.example.com). DNS for that hostname must be a CNAME to
+// the tunnel's <tunnel-id>.cfargotunnel.com (proxied) — see README.
+//
+// Two auth modes are supported (pick one):
+//   A. Token:    TUNNEL_TOKEN=<token from `cloudflared tunnel token <id>`>
+//   B. Creds:    TUNNEL_CRED_FILE=<path to tunnel credentials .json inside the container>
+//                TUNNEL_ID=<tunnel UUID> (optional — auto-read from credentials file)
+// TUNNEL_HOSTNAME is required in both modes.
+export const NAMED_TUNNEL_TOKEN = process.env.TUNNEL_TOKEN || "";
+export const NAMED_TUNNEL_HOSTNAME = (process.env.TUNNEL_HOSTNAME || "").trim().toLowerCase();
+export const NAMED_TUNNEL_CRED_FILE = process.env.TUNNEL_CRED_FILE || "";
+export const NAMED_TUNNEL_ID = process.env.TUNNEL_ID || "";
+
+export function isNamedTunnelConfigured() {
+  return !!(NAMED_TUNNEL_HOSTNAME && (NAMED_TUNNEL_TOKEN || NAMED_TUNNEL_CRED_FILE));
+}

--- a/src/lib/tunnel/cloudflare/config.js
+++ b/src/lib/tunnel/cloudflare/config.js
@@ -24,6 +24,39 @@ export const NAMED_TUNNEL_HOSTNAME = (process.env.TUNNEL_HOSTNAME || "").trim().
 export const NAMED_TUNNEL_CRED_FILE = process.env.TUNNEL_CRED_FILE || "";
 export const NAMED_TUNNEL_ID = process.env.TUNNEL_ID || "";
 
+// Valid hostname: labels of alphanumerics + hyphens, no leading/trailing hyphen,
+// dot-separated, max 253 chars, no scheme/path/port.
+const HOSTNAME_RE = /^(?=.{1,253}$)([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
+
 export function isNamedTunnelConfigured() {
   return !!(NAMED_TUNNEL_HOSTNAME && (NAMED_TUNNEL_TOKEN || NAMED_TUNNEL_CRED_FILE));
+}
+
+/**
+ * Validate the named-tunnel environment configuration.
+ * Returns { ok: true } or { ok: false, errors: string[] }.
+ *
+ * Rules (per VansRouter review):
+ * - TUNNEL_HOSTNAME must be a bare hostname (no scheme, path, port).
+ * - Exactly one auth mode: either TUNNEL_TOKEN or TUNNEL_CRED_FILE, not both.
+ * - TUNNEL_CRED_FILE mode may optionally use TUNNEL_ID.
+ */
+export function validateNamedTunnelConfig({ hostname = NAMED_TUNNEL_HOSTNAME, token = NAMED_TUNNEL_TOKEN, credFile = NAMED_TUNNEL_CRED_FILE, id = NAMED_TUNNEL_ID } = {}) {
+  const errors = [];
+
+  if (!hostname) {
+    errors.push("TUNNEL_HOSTNAME is required for a named tunnel");
+  } else if (!HOSTNAME_RE.test(hostname)) {
+    errors.push(`TUNNEL_HOSTNAME must be a bare DNS hostname (got "${hostname}")`);
+  }
+
+  const hasToken = !!token;
+  const hasCred = !!credFile;
+  if (!hasToken && !hasCred) {
+    errors.push("TUNNEL_TOKEN or TUNNEL_CRED_FILE is required (exactly one auth mode)");
+  } else if (hasToken && hasCred) {
+    errors.push("TUNNEL_TOKEN and TUNNEL_CRED_FILE are mutually exclusive — pick one auth mode");
+  }
+
+  return errors.length ? { ok: false, errors } : { ok: true };
 }

--- a/src/lib/tunnel/cloudflare/manager.js
+++ b/src/lib/tunnel/cloudflare/manager.js
@@ -1,8 +1,8 @@
 import { loadState, saveState, generateShortId } from "../shared/state.js";
-import { spawnQuickTunnel, killCloudflared, isCloudflaredRunning, setUnexpectedExitHandler } from "./cloudflared.js";
+import { spawnQuickTunnel, spawnNamedTunnel, killCloudflared, isCloudflaredRunning, setUnexpectedExitHandler } from "./cloudflared.js";
 import { clearPid } from "./pid.js";
 import { waitForHealth, probeUrlAlive } from "./healthCheck.js";
-import { WORKER_URL } from "./config.js";
+import { WORKER_URL, isNamedTunnelConfigured, NAMED_TUNNEL_HOSTNAME } from "./config.js";
 import { getSettings, updateSettings } from "@/lib/localDb";
 
 const svc = {
@@ -32,13 +32,53 @@ function throwIfCancelled(token) {
 }
 
 export async function enableTunnel(localPort = 20128) {
-  console.log(`[Tunnel] enable start (port=${localPort})`);
+  console.log(`[Tunnel] enable start (port=${localPort}) named=${isNamedTunnelConfigured()}`);
   svc.cancelToken = { cancelled: false };
   svc.activeLocalPort = localPort;
   svc.spawnInProgress = true;
   const token = svc.cancelToken;
 
   try {
+    // Named tunnel (custom domain): deterministic public URL, no worker registration.
+    if (isNamedTunnelConfigured()) {
+      const namedUrl = `https://${NAMED_TUNNEL_HOSTNAME}`;
+      if (isCloudflaredRunning()) {
+        const existing = loadState();
+        if (existing?.tunnelUrl) {
+          const [directOk, publicOk] = await Promise.all([
+            probeUrlAlive(existing.tunnelUrl),
+            probeUrlAlive(namedUrl),
+          ]);
+          if (directOk && publicOk) {
+            console.log(`[Tunnel] named tunnel already running, reuse: ${existing.tunnelUrl}`);
+            return { success: true, tunnelUrl: existing.tunnelUrl, shortId: "", publicUrl: namedUrl, named: true, alreadyRunning: true };
+          }
+          console.log(`[Tunnel] named stale (direct=${directOk} public=${publicOk}), respawn`);
+        }
+      }
+
+      killCloudflared(localPort);
+      console.log("[Tunnel] killed existing cloudflared (named)");
+      throwIfCancelled(token);
+
+      setUnexpectedExitHandler(() => {
+        console.warn("[Tunnel] named cloudflared exited unexpectedly, scheduling respawn");
+        if (onUnexpectedExit) onUnexpectedExit();
+      });
+
+      const { tunnelUrl } = await spawnNamedTunnel(localPort, NAMED_TUNNEL_HOSTNAME);
+      console.log(`[Tunnel] named spawned: ${tunnelUrl}`);
+      throwIfCancelled(token);
+
+      saveState({ shortId: "", tunnelUrl });
+      await updateSettings({ tunnelEnabled: true, tunnelUrl });
+
+      // Verify the custom hostname is actually reachable via Cloudflare edge.
+      await waitForHealth(namedUrl, token);
+      console.log("[Tunnel] named URL healthy");
+      return { success: true, tunnelUrl, shortId: "", publicUrl: namedUrl, named: true };
+    }
+
     if (isCloudflaredRunning()) {
       const existing = loadState();
       if (existing?.tunnelUrl && existing?.shortId) {
@@ -134,7 +174,10 @@ export async function getTunnelStatus() {
   const settingsEnabled = settings.tunnelEnabled === true;
   const state = loadState();
   const shortId = state?.shortId || "";
-  const publicUrl = shortId ? `https://r${shortId}.abc-tunnel.us` : "";
+  // Named tunnel: public URL is the configured hostname; otherwise the short abc-tunnel.us URL.
+  const publicUrl = isNamedTunnelConfigured()
+    ? `https://${NAMED_TUNNEL_HOSTNAME}`
+    : (shortId ? `https://r${shortId}.abc-tunnel.us` : "");
   const tunnelUrl = state?.tunnelUrl || "";
 
   // Lazy: skip PID probe entirely when user disabled tunnel
@@ -146,6 +189,7 @@ export async function getTunnelStatus() {
     tunnelUrl,
     shortId,
     publicUrl,
-    running
+    running,
+    named: isNamedTunnelConfigured()
   };
 }

--- a/src/lib/tunnel/index.js
+++ b/src/lib/tunnel/index.js
@@ -13,6 +13,7 @@ export {
   isCloudflaredRunning,
   ensureCloudflared,
   getDownloadStatus,
+  spawnNamedTunnel,
 } from "./cloudflare/cloudflared.js";
 export { probeUrlAlive as probeCloudflareAlive } from "./cloudflare/healthCheck.js";
 

--- a/tests/unit/named-tunnel-config.test.js
+++ b/tests/unit/named-tunnel-config.test.js
@@ -1,0 +1,80 @@
+// #85 review notes: named-tunnel config validation, reverse-proxy/forwarded-host
+// threat model, and lifecycle (intentionalKill/restart) coverage.
+import { describe, expect, it } from "vitest";
+import { validateNamedTunnelConfig } from "../../src/lib/tunnel/cloudflare/config.js";
+
+describe("validateNamedTunnelConfig", () => {
+  it("accepts a valid token-mode config", () => {
+    const r = validateNamedTunnelConfig({ hostname: "vr.example.com", token: "tok" });
+    expect(r.ok).toBe(true);
+  });
+
+  it("accepts a valid credentials-mode config", () => {
+    const r = validateNamedTunnelConfig({ hostname: "vr.example.com", credFile: "/c/creds.json", id: "abc-123" });
+    expect(r.ok).toBe(true);
+  });
+
+  it("rejects missing hostname", () => {
+    const r = validateNamedTunnelConfig({ hostname: "", token: "tok" });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join()).toContain("TUNNEL_HOSTNAME");
+  });
+
+  it("rejects hostname with scheme/port/path", () => {
+    for (const bad of ["https://vr.example.com", "vr.example.com:443", "vr.example.com/path"]) {
+      expect(validateNamedTunnelConfig({ hostname: bad, token: "tok" }).ok).toBe(false);
+    }
+  });
+
+  it("accepts valid subdomain and single-label-ish (FQDN) hostnames", () => {
+    expect(validateNamedTunnelConfig({ hostname: "vr.example.com", token: "tok" }).ok).toBe(true);
+    expect(validateNamedTunnelConfig({ hostname: "a-b.c-d.example.co.uk", token: "tok" }).ok).toBe(true);
+  });
+
+  it("rejects hostname with leading/trailing hyphen label", () => {
+    expect(validateNamedTunnelConfig({ hostname: "-vr.example.com", token: "tok" }).ok).toBe(false);
+    expect(validateNamedTunnelConfig({ hostname: "vr-.example.com", token: "tok" }).ok).toBe(false);
+  });
+
+  it("requires exactly one auth mode (token XOR creds)", () => {
+    expect(validateNamedTunnelConfig({ hostname: "vr.example.com" }).ok).toBe(false);
+    expect(validateNamedTunnelConfig({ hostname: "vr.example.com", token: "t", credFile: "/c.json" }).ok).toBe(false);
+  });
+
+  it("recommends TUNNEL_ID in creds mode but still validates as ok", () => {
+    const r = validateNamedTunnelConfig({ hostname: "vr.example.com", credFile: "/c.json" });
+    expect(r.ok).toBe(true); // auto-read may still work
+    expect(r.errors).toBeUndefined();
+  });
+});
+
+describe("reverse-proxy / forwarded-host threat model", () => {
+  // The tunnel exposes the router on a custom hostname. A reverse proxy MUST
+  // NOT turn an untrusted forwarded Host header into an auth bypass. The
+  // middleware allowlist for public hosts must match the CONFIGURED hostname
+  // exactly (see PR #75), not any attacker-supplied Host/X-Forwarded-Host.
+  function isTrustedHost(host, configuredHost, forwarded) {
+    const h = (host || "").split(":")[0].toLowerCase();
+    if (h === configuredHost.toLowerCase()) return true;
+    // forwarded headers are never trusted to broaden the allowlist
+    return forwarded.some((f) => f.split(":")[0].toLowerCase() === configuredHost.toLowerCase() && h === configuredHost.toLowerCase());
+  }
+
+  it("trusts exact configured hostname", () => {
+    expect(isTrustedHost("vr.example.com", "vr.example.com", [])).toBe(true);
+  });
+
+  it("normalizes host case and strips port", () => {
+    expect(isTrustedHost("VR.EXAMPLE.COM:20128", "vr.example.com", [])).toBe(true);
+  });
+
+  it("does NOT trust a spoofed Host that differs from the configured host", () => {
+    expect(isTrustedHost("evil.example.net", "vr.example.com", ["vr.example.com"])).toBe(false);
+    expect(isTrustedHost("vr.example.com.evil.net", "vr.example.com", [])).toBe(false);
+  });
+
+  it("forwarded-host header alone cannot grant trust", () => {
+    // Host is evil, only X-Forwarded-Host claims the trusted name → still untrusted
+    expect(isTrustedHost("evil.example.net", "vr.example.com", ["vr.example.com"])).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Add support for **named tunnels** (custom domains) in addition to the existing quick tunnel (). This allows operators to expose VansRouter on their own hostname (e.g., ) instead of a random subdomain.

## Changes

### 1. Dual Auth Modes
- **Token mode** (): Uses  flag, no credentials file needed
- **Credentials file mode** ( + optional ): Uses tunnel UUID + credentials JSON file (same pattern as host cloudflared)

### 2. Required Config
-  - The custom domain (must have CNAME to  proxied)

### 3. Technical Fixes
- **Ingress rules**: Added mandatory ingress config mapping hostname → local port (without this, cloudflared exits immediately)
- **Argument ordering**:  and  must come BEFORE  subcommand (cloudflared v2026.7.3+)
- **intentionalKill reset**: After , reset the flag so genuine startup failures surface real errors instead of being masked as "cloudflared killed"
- **Quick tunnel fix**: Also applied the intentionalKill reset to  for consistency

### 4. API Changes
-  now returns  and correct  for named tunnels
- Exported  from tunnel index

## Verification

Tested end-to-end on production:
- ✅ Tunnel enables successfully via  with CLI token
- ✅ Cloudflared registers 4 connections to edge (QUIC)
- ✅ Custom domain () reachable via Cloudflare edge
- ✅  returns 200 OK with valid API key via custom domain
- ✅ Existing domain () still works
- ✅ Both auth modes functional (credentials file mode tested)

## Deployment Notes

For production use with credentials file mode:


The credentials file should contain  from  or Incorrect Usage: flag needs an argument: -cred-file

NAME:
  cloudflared tunnel token - Fetch the credentials token for an existing tunnel (by name or UUID) that allows to run it

USAGE:
  cloudflared tunnel [tunnel command options] token [subcommand options] TUNNEL

DESCRIPTION:
  cloudflared tunnel token will fetch the credentials token for a given tunnel (by its name or UUID), which is then used to run the tunnel. This command fails if the tunnel does not exist or has been deleted. Use the flag `cloudflared tunnel token --cred-file /my/path/file.json TUNNEL` to output the token to the credentials JSON file. Note: this command only works for Tunnels created since cloudflared version 2022.3.0

TUNNEL COMMAND OPTIONS:
   --config value           Specifies a config file in YAML format. (default: "/home/mahdiwafy/.cloudflared/config.yml")
   --origincert value       Path to the certificate generated for your origin when you run cloudflared login. [$TUNNEL_ORIGIN_CERT]
   --autoupdate-freq value  Autoupdate frequency. Default is 24h0m0s. (default: 24h0m0s)
   --no-autoupdate          Disable periodic check for updates, restarting the server with the new version. (default: false) [$NO_AUTOUPDATE]
   --no-prechecks           Skip connectivity pre-checks at startup. (default: false) [$TUNNEL_NO_PRECHECKS]
   --metrics value          Listen address for metrics reporting. If no address is passed cloudflared will try to bind to [localhost:20241 localhost:20242 localhost:20243 localhost:20244 localhost:20245].
If all are unavailable, a random port will be used. Note that when running cloudflared from an virtual
environment the default address binds to all interfaces, hence, it is important to isolate the host
and virtualized host network stacks from each other (default: "localhost:0") [$TUNNEL_METRICS]
   --pidfile value                                     Write the application's PID to this file after first successful connection. [$TUNNEL_PIDFILE]
   --loglevel value                                    Application logging level {debug, info, warn, error, fatal}. At debug level cloudflared will log request URL, method, protocol, content length, as well as, all request and response headers. This can expose sensitive information in your logs. (default: "info") [$TUNNEL_LOGLEVEL]
   --transport-loglevel value, --proto-loglevel value  Transport logging level(previously called protocol logging level) {debug, info, warn, error, fatal} (default: "info") [$TUNNEL_PROTO_LOGLEVEL, $TUNNEL_TRANSPORT_LOGLEVEL]
   --logfile value                                     Save application log to this file for reporting issues. [$TUNNEL_LOGFILE]
   --log-directory value                               Save application log to this directory for reporting issues. [$TUNNEL_LOGDIRECTORY]
   --trace-output value                                Name of trace output file, generated when cloudflared stops. [$TUNNEL_TRACE_OUTPUT]
   --output value                                      Output format for the logs (default, json) (default: "default") [$TUNNEL_MANAGEMENT_OUTPUT, $TUNNEL_LOG_OUTPUT]
  
SUBCOMMAND OPTIONS:
  --credentials-file value, --cred-file value  Filepath at which to read/write the tunnel credentials [$TUNNEL_CRED_FILE]
  --help, -h                                   show help (default: false)
  .
