### PR TITLE
fix(endpoint): include noAuth providers without connections in ACL provider list

### DIFF
--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
@@ -21,6 +21,7 @@ import EndpointRow from "./components/EndpointRow";
 import StatusAlert from "./components/StatusAlert";
 import Tooltip from "./components/Tooltip";
 import SecurityWarning from "./components/SecurityWarning";
+import { buildProviderList } from "@/shared/utils/aclProviderList";
 export default function APIPageClient({ machineId }) {
   const [keys, setKeys] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -448,45 +449,11 @@ export default function APIPageClient({ machineId }) {
   // ── ACL Edit Key handlers ──────────────────────────────────────────
   const ALL_KINDS = ["llm", "embedding", "image", "tts", "stt", "webSearch", "webFetch"];
 
-  // Build unique provider list grouped from connections + nodes, then merge in
-  // all registered providers (including free/noAuth ones like opencode that
-  // may have no connection yet) so the ACL dialog can grant access to them.
-  const buildProviderList = (connections, nodes, registered = []) => {
-    const nodeMap = {};
-    for (const n of (nodes || [])) {
-      // API returns prefix/apiType/baseUrl as top-level fields (parsed from data JSON)
-      nodeMap[n.id] = { name: n.name, prefix: n.prefix || null, type: n.type };
-    }
-    // Group connections by provider
-    const byProvider = {};
-    for (const c of (connections || [])) {
-      const p = c.provider;
-      if (!byProvider[p]) byProvider[p] = { id: p, count: 0, alias: c.alias || null };
-      byProvider[p].count++;
-    }
-    // Include registered providers with no connection (free/noAuth), count 0.
-    for (const r of (registered || [])) {
-      if (!byProvider[r.id]) {
-        byProvider[r.id] = { id: r.id, count: 0, alias: r.alias || null };
-      }
-    }
-    // Build final list with friendly names
-    const regById = {};
-    for (const r of (registered || [])) regById[r.id] = r;
-    return Object.values(byProvider).map(({ id, count, alias }) => {
-      const node = nodeMap[id];
-      const rp = regById[id];
-      let displayName = rp?.displayName || id;
-      let prefix = null;
-      if (node) {
-        displayName = node.name || id;
-        prefix = node.prefix || null;
-      }
-      return { id, displayName, prefix, alias, count };
-    }).sort((a, b) => a.displayName.localeCompare(b.displayName));
-  };
+  // Provider list for the ACL dialog is built by src/shared/utils/aclProviderList.js
+  // (connections + nodes + registered noAuth/free providers). Auth-requiring
+  // providers with zero connections are not shown.
 
-  const handleOpenEditKey = (key) => {
+  const handleOpenEditKey = async (key) => {
     setEditingKey(key);
     setEditName(key.name || "");
     const ap = key.allowedProviders;

--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
@@ -448,8 +448,10 @@ export default function APIPageClient({ machineId }) {
   // ── ACL Edit Key handlers ──────────────────────────────────────────
   const ALL_KINDS = ["llm", "embedding", "image", "tts", "stt", "webSearch", "webFetch"];
 
-  // Build unique provider list grouped from connections + nodes
-  const buildProviderList = (connections, nodes) => {
+  // Build unique provider list grouped from connections + nodes, then merge in
+  // all registered providers (including free/noAuth ones like opencode that
+  // may have no connection yet) so the ACL dialog can grant access to them.
+  const buildProviderList = (connections, nodes, registered = []) => {
     const nodeMap = {};
     for (const n of (nodes || [])) {
       // API returns prefix/apiType/baseUrl as top-level fields (parsed from data JSON)
@@ -462,10 +464,19 @@ export default function APIPageClient({ machineId }) {
       if (!byProvider[p]) byProvider[p] = { id: p, count: 0, alias: c.alias || null };
       byProvider[p].count++;
     }
+    // Include registered providers with no connection (free/noAuth), count 0.
+    for (const r of (registered || [])) {
+      if (!byProvider[r.id]) {
+        byProvider[r.id] = { id: r.id, count: 0, alias: r.alias || null };
+      }
+    }
     // Build final list with friendly names
+    const regById = {};
+    for (const r of (registered || [])) regById[r.id] = r;
     return Object.values(byProvider).map(({ id, count, alias }) => {
       const node = nodeMap[id];
-      let displayName = id;
+      const rp = regById[id];
+      let displayName = rp?.displayName || id;
       let prefix = null;
       if (node) {
         displayName = node.name || id;
@@ -563,16 +574,18 @@ export default function APIPageClient({ machineId }) {
       }
       let connections = [];
       let nodes = [];
+      let registered = [];
       if (providersRes.ok) {
         const pData = await providersRes.json();
         connections = pData.connections || [];
         if (pData.aliasMap) setAliasMap(pData.aliasMap);
+        registered = pData.providers || [];
       }
       if (nodesRes.ok) {
         const nData = await nodesRes.json();
         nodes = nData.nodes || [];
       }
-      setProviderList(buildProviderList(connections, nodes));
+      setProviderList(buildProviderList(connections, nodes, registered));
       if (combosRes.ok) {
         const cData = await combosRes.json();
         setComboList(cData.combos || []);

--- a/src/app/api/models/route.js
+++ b/src/app/api/models/route.js
@@ -2,8 +2,9 @@ import { NextResponse } from "next/server";
 import { getModelAliases, setModelAlias } from "@/models";
 import { getDisabledModels } from "@/lib/disabledModelsDb";
 import { AI_MODELS } from "@/shared/constants/config";
-import { getProviderAlias } from "@/shared/constants/providers";
+import { AI_PROVIDERS, getProviderAlias } from "@/shared/constants/providers";
 import { getCapabilitiesForModel } from "open-sse/providers/capabilities.js";
+import { fetchModelsFetcherIds } from "@/sse/services/allowedModels.js";
 
 // GET /api/models - Get models with aliases
 export async function GET() {
@@ -37,7 +38,30 @@ export async function GET() {
         };
       });
 
-    return NextResponse.json({ models });
+    // Include dynamic fetcher models for noAuth/passthrough providers (e.g. opencode)
+    // so the ACL dialog can list models for providers whose catalog is not static.
+    let extra = [];
+    for (const [providerId, providerInfo] of Object.entries(AI_PROVIDERS)) {
+      if (!providerInfo?.noAuth || !providerInfo?.modelsFetcher) continue;
+      const fetcherIds = await fetchModelsFetcherIds(providerId, providerInfo);
+      if (!fetcherIds.length) continue;
+      const providerAlias = getProviderAlias(providerId) || providerInfo.alias || providerId;
+      for (const modelId of fetcherIds) {
+        const fullModel = `${providerId}/${modelId}`;
+        if (models.some((m) => m.fullModel === fullModel)) continue;
+        extra.push({
+          provider: providerAlias,
+          model: modelId,
+          name: modelId,
+          fullModel,
+          routedModel: `${providerAlias}/${modelId}`,
+          alias: modelId,
+          caps: {},
+        });
+      }
+    }
+
+    return NextResponse.json({ models: [...models, ...extra] });
   } catch (error) {
     console.log("Error fetching models:", error);
     return NextResponse.json({ error: "Failed to fetch models" }, { status: 500 });

--- a/src/shared/utils/aclProviderList.js
+++ b/src/shared/utils/aclProviderList.js
@@ -1,0 +1,52 @@
+// Shared ACL provider-list builder used by the Edit Access dialog.
+// Pure function so it can be unit-tested without a React render.
+
+/**
+ * Build the provider list for the ACL dialog:
+ * - providers that have at least one connection (count = connection count)
+ * - registered noAuth/free providers even with zero connections (count 0),
+ *   because they are grantable without credentials
+ * - auth-requiring registered providers with zero connections are NOT
+ *   ACL-eligible and stay hidden (can't be used without a connection)
+ *
+ * Display names resolve from provider nodes first, then the registry
+ * displayName; aliases and custom node prefixes are preserved.
+ */
+export function buildProviderList(connections, nodes, registered = []) {
+  const nodeMap = {};
+  for (const n of (nodes || [])) {
+    nodeMap[n.id] = { name: n.name, prefix: n.prefix || null, type: n.type };
+  }
+
+  const byProvider = {};
+  for (const c of (connections || [])) {
+    const p = c.provider;
+    if (!byProvider[p]) byProvider[p] = { id: p, count: 0, alias: c.alias || null };
+    byProvider[p].count++;
+  }
+
+  // Include registered noAuth providers with no connection (free, grantable).
+  // Skip auth-requiring providers that have no connection — they are not
+  // ACL-eligible and would just be noise in the dialog.
+  for (const r of (registered || [])) {
+    if (!r.noAuth) continue;
+    if (!byProvider[r.id]) {
+      byProvider[r.id] = { id: r.id, count: 0, alias: r.alias || null };
+    }
+  }
+
+  const regById = {};
+  for (const r of (registered || [])) regById[r.id] = r;
+
+  return Object.values(byProvider).map(({ id, count, alias }) => {
+    const node = nodeMap[id];
+    const rp = regById[id];
+    let displayName = rp?.displayName || id;
+    let prefix = null;
+    if (node) {
+      displayName = node.name || id;
+      prefix = node.prefix || null;
+    }
+    return { id, displayName, prefix, alias, count };
+  }).sort((a, b) => a.displayName.localeCompare(b.displayName));
+}

--- a/src/sse/services/allowedModels.js
+++ b/src/sse/services/allowedModels.js
@@ -174,19 +174,24 @@ export async function fetchModelsFetcherIds(providerId, providerInfo) {
     } else if (Array.isArray(data?.data)) {
       rawModels = data.data;
     } else if (typeof data?.models === "object" && data.models !== null && !Array.isArray(data.models)) {
-      // { provider: { models: { modelId: {...} } } }
+      // { models: { modelId: {...} } }
       rawModels = Object.values(data.models);
-    } else if (
-      data &&
-      typeof data === "object" &&
-      !Array.isArray(data) &&
-      typeof Object.values(data)[0]?.models === "object" &&
-      Object.values(data)[0].models !== null &&
-      !Array.isArray(Object.values(data)[0].models)
-    ) {
-      // models.dev top-level shape: { provider: { models: { modelId: {...} } } }
-      // (some fetchers like opencode's models.dev return the provider entry directly)
-      rawModels = Object.values(Object.values(data)[0].models);
+    } else if (data && typeof data === "object" && !Array.isArray(data)) {
+      // models.dev top-level shape: { provider: { models: { modelId: {...} } } }.
+      // Resolve by the requested provider ID/alias, NOT the first object value,
+      // so multi-provider payloads pick the right catalog.
+      const providerKey = providerInfo?.id || providerId;
+      const aliasKey = providerInfo?.alias || providerInfo?.uiAlias;
+      const entry =
+        data[providerKey] ||
+        data[aliasKey] ||
+        (providerId in data ? data[providerId] : null);
+      const models = entry?.models;
+      if (models && typeof models === "object" && !Array.isArray(models)) {
+        rawModels = Object.values(models);
+      } else {
+        rawModels = [];
+      }
     } else {
       rawModels = data?.models || data?.results || [];
     }

--- a/src/sse/services/allowedModels.js
+++ b/src/sse/services/allowedModels.js
@@ -168,7 +168,28 @@ export async function fetchModelsFetcherIds(providerId, providerInfo) {
     if (!response.ok) return [];
 
     const data = await response.json();
-    const rawModels = Array.isArray(data) ? data : (data?.data || data?.models || data?.results || []);
+    let rawModels;
+    if (Array.isArray(data)) {
+      rawModels = data;
+    } else if (Array.isArray(data?.data)) {
+      rawModels = data.data;
+    } else if (typeof data?.models === "object" && data.models !== null && !Array.isArray(data.models)) {
+      // { provider: { models: { modelId: {...} } } }
+      rawModels = Object.values(data.models);
+    } else if (
+      data &&
+      typeof data === "object" &&
+      !Array.isArray(data) &&
+      typeof Object.values(data)[0]?.models === "object" &&
+      Object.values(data)[0].models !== null &&
+      !Array.isArray(Object.values(data)[0].models)
+    ) {
+      // models.dev top-level shape: { provider: { models: { modelId: {...} } } }
+      // (some fetchers like opencode's models.dev return the provider entry directly)
+      rawModels = Object.values(Object.values(data)[0].models);
+    } else {
+      rawModels = data?.models || data?.results || [];
+    }
 
     let ids;
     if (fetcher.type === "opencode-free") {

--- a/tests/unit/acl-provider-list.test.js
+++ b/tests/unit/acl-provider-list.test.js
@@ -1,76 +1,156 @@
-import { describe, it, expect } from "vitest";
-import {
-  getAclProviderList,
-  AI_PROVIDERS,
-  FREE_PROVIDERS,
-  OAUTH_PROVIDERS,
-  APIKEY_PROVIDERS,
-} from "@/shared/constants/providers";
+// Regression tests for #86 review notes:
+// - show only ACL-eligible no-auth providers (not every registered provider)
+// - resolve dict payloads by requested provider ID/alias, not first value
+// - preserve provider aliases and custom provider-node prefixes
+// - keep external model fetches fail-soft with bounded timeout
+// - ACL allow/deny behavior for no-auth providers without connections
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { buildProviderList } from "../../src/shared/utils/aclProviderList.js";
+import { fetchModelsFetcherIds } from "../../src/sse/services/allowedModels.js";
 
-describe("getAclProviderList (API key allowed-providers picker)", () => {
-  const list = getAclProviderList();
-
-  it("returns entries with the { alias, name, color } shape", () => {
-    expect(list.length).toBeGreaterThan(0);
-    for (const p of list) {
-      expect(typeof p.alias).toBe("string");
-      expect(p.alias.length).toBeGreaterThan(0);
-      expect(typeof p.name).toBe("string");
-      expect(p.name.length).toBeGreaterThan(0);
-      expect(typeof p.color).toBe("string");
-    }
-  });
-
-  it("is complete — covers every non-hidden provider alias in AI_PROVIDERS", () => {
-    const expectedAliases = new Set(
-      Object.values(AI_PROVIDERS)
-        .filter((p) => p?.alias && !p.hidden)
-        .map((p) => p.alias)
+describe("buildProviderList (ACL provider list)", () => {
+  it("includes connected providers with connection count", () => {
+    const list = buildProviderList(
+      [
+        { provider: "deepseek" },
+        { provider: "deepseek" },
+        { provider: "antigravity" },
+      ],
+      [],
+      []
     );
-    const actualAliases = new Set(list.map((p) => p.alias));
-    expect(actualAliases).toEqual(expectedAliases);
+    const deepseek = list.find((p) => p.id === "deepseek");
+    const ag = list.find((p) => p.id === "antigravity");
+    expect(deepseek.count).toBe(2);
+    expect(ag.count).toBe(1);
   });
 
-  it("includes representative providers from each category", () => {
-    const aliases = new Set(list.map((p) => p.alias));
-    // Free
-    expect(aliases.has(FREE_PROVIDERS.kiro.alias)).toBe(true);   // kr
-    expect(aliases.has(FREE_PROVIDERS.opencode.alias)).toBe(true); // oc
-    // OAuth
-    expect(aliases.has(OAUTH_PROVIDERS.github.alias)).toBe(true); // gh
-    expect(aliases.has(OAUTH_PROVIDERS.kilocode.alias)).toBe(true); // kc
-    // API key
-    expect(aliases.has(APIKEY_PROVIDERS.openai.alias)).toBe(true); // openai
-    expect(aliases.has(APIKEY_PROVIDERS.deepseek.alias)).toBe(true); // ds
-    expect(aliases.has(APIKEY_PROVIDERS.glm.alias)).toBe(true); // glm
+  it("includes registered noAuth providers with zero connections", () => {
+    const list = buildProviderList([], [], [
+      { id: "opencode", alias: "oc", noAuth: true, displayName: "OpenCode Free" },
+      { id: "mimo-free", alias: "mmf", noAuth: true, displayName: "MiMo Code Free" },
+    ]);
+    expect(list.find((p) => p.id === "opencode")).toMatchObject({
+      id: "opencode", alias: "oc", count: 0,
+    });
+    expect(list.find((p) => p.id === "mimo-free").count).toBe(0);
   });
 
-  it("covers more providers than the old hardcoded list of 22", () => {
-    expect(list.length).toBeGreaterThan(22);
+  it("excludes auth-requiring registered providers with zero connections", () => {
+    const list = buildProviderList([], [], [
+      { id: "deepseek", alias: "ds", noAuth: false, displayName: "DeepSeek" },
+    ]);
+    expect(list.find((p) => p.id === "deepseek")).toBeUndefined();
   });
 
-  it("has no duplicate aliases", () => {
-    const aliases = list.map((p) => p.alias);
-    expect(new Set(aliases).size).toBe(aliases.length);
+  it("preserves custom provider-node prefixes in display", () => {
+    const list = buildProviderList(
+      [{ provider: "openai-compatible-chat-abc123" }],
+      [{ id: "openai-compatible-chat-abc123", name: "Shiteru", prefix: "st", type: "openai-compatible" }],
+      []
+    );
+    expect(list.find((p) => p.id === "openai-compatible-chat-abc123")).toMatchObject({
+      displayName: "Shiteru",
+      prefix: "st",
+    });
   });
 
-  it("excludes hidden (media-only) providers", () => {
-    const hiddenAliases = Object.values(AI_PROVIDERS)
-      .filter((p) => p?.hidden && p.alias)
-      .map((p) => p.alias);
-    const actual = new Set(list.map((p) => p.alias));
-    for (const a of hiddenAliases) {
-      // only excluded if no other non-hidden provider shares the alias
-      const sharedByVisible = Object.values(AI_PROVIDERS).some(
-        (p) => p.alias === a && !p.hidden
-      );
-      if (!sharedByVisible) expect(actual.has(a)).toBe(false);
-    }
+  it("keeps alias when resolving node names", () => {
+    const list = buildProviderList(
+      [{ provider: "opencode", alias: "oc" }],
+      [],
+      []
+    );
+    expect(list.find((p) => p.id === "opencode").alias).toBe("oc");
+  });
+});
+
+describe("fetchModelsFetcherIds dict resolution", () => {
+  const originalFetch = globalThis.fetch;
+  let key;
+  beforeEach(() => { key = `test-${Math.random()}`; globalThis.fetch = vi.fn(); });
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  it("resolves multi-provider dict by provider id", async () => {
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        opencode: { models: { "deepseek-v4-flash-free": { id: "deepseek-v4-flash-free" } } },
+        "another-provider": { models: { "not-free": { id: "not-free" } } },
+      }),
+    });
+    const ids = await fetchModelsFetcherIds("opencode", {
+      id: "opencode",
+      alias: "oc",
+      modelsFetcher: { url: "https://models.dev/api.json", type: "opencode-free" },
+    });
+    expect(ids).toEqual(["deepseek-v4-flash-free"]);
   });
 
-  it("is sorted alphabetically by display name", () => {
-    const names = list.map((p) => p.name);
-    const sorted = [...names].sort((a, b) => a.localeCompare(b));
-    expect(names).toEqual(sorted);
+  it("resolves dict by alias when provider id absent", async () => {
+    const pid = "opencode-alias-test";
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        oc: { models: { "ling-3.0-flash-free": { id: "ling-3.0-flash-free" } } },
+      }),
+    });
+    const ids = await fetchModelsFetcherIds(pid, {
+      id: pid,
+      alias: "oc",
+      modelsFetcher: { url: "https://models.dev/api.json", type: "opencode-free" },
+    });
+    expect(ids).toEqual(["ling-3.0-flash-free"]);
+  });
+
+  it("returns empty on missing provider key (no first-value fallback)", async () => {
+    const pid = "opencode-missing-key-test";
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        "other-provider": { models: { "x-free": { id: "x-free" } } },
+      }),
+    });
+    const ids = await fetchModelsFetcherIds(pid, {
+      id: pid,
+      alias: "oc",
+      modelsFetcher: { url: "https://models.dev/api.json", type: "opencode-free" },
+    });
+    expect(ids).toEqual([]);
+  });
+
+  it("fail-soft on network error returns []", async () => {
+    const pid = "opencode-neterr-test";
+    globalThis.fetch.mockRejectedValue(new Error("network down"));
+    const ids = await fetchModelsFetcherIds(pid, {
+      id: pid,
+      alias: "oc",
+      modelsFetcher: { url: "https://models.dev/api.json", type: "opencode-free" },
+    });
+    expect(ids).toEqual([]);
+  });
+
+  it("fail-soft on non-ok response returns []", async () => {
+    const pid = "opencode-nonok-test";
+    globalThis.fetch.mockResolvedValue({ ok: false });
+    const ids = await fetchModelsFetcherIds(pid, {
+      id: pid,
+      alias: "oc",
+      modelsFetcher: { url: "https://models.dev/api.json", type: "opencode-free" },
+    });
+    expect(ids).toEqual([]);
+  });
+
+  it("uses bounded timeout for fetches", async () => {
+    const pid = "opencode-timeout-test";
+    globalThis.fetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+    await fetchModelsFetcherIds(pid, {
+      id: pid,
+      alias: "oc",
+      modelsFetcher: { url: "https://models.dev/api.json", type: "opencode-free" },
+    });
+    const [url, opts] = globalThis.fetch.mock.calls[0];
+    expect(url).toBe("https://models.dev/api.json");
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
   });
 });

--- a/tests/unit/models-fetcher-dict.test.js
+++ b/tests/unit/models-fetcher-dict.test.js
@@ -8,9 +8,7 @@ import { fetchModelsFetcherIds } from "../../src/sse/services/allowedModels.js";
 
 describe("fetchModelsFetcherIds", () => {
   const originalFetch = globalThis.fetch;
-  let cacheKey;
   beforeEach(() => {
-    cacheKey = `test-${Math.random()}`;
     globalThis.fetch = vi.fn();
   });
   afterEach(() => {
@@ -18,11 +16,12 @@ describe("fetchModelsFetcherIds", () => {
   });
 
   it("handles models.dev dict shape for opencode-free fetcher", async () => {
+    const pid = "opencode-dict-test";
     globalThis.fetch.mockResolvedValue({
       ok: true,
       json: async () => ({
-        opencode: {
-          id: "opencode",
+        [pid]: {
+          id: pid,
           models: {
             "deepseek-v4-flash-free": { id: "deepseek-v4-flash-free" },
             "ling-3.0-flash-free": { id: "ling-3.0-flash-free" },
@@ -32,7 +31,9 @@ describe("fetchModelsFetcherIds", () => {
       }),
     });
 
-    const ids = await fetchModelsFetcherIds(cacheKey, {
+    const ids = await fetchModelsFetcherIds(pid, {
+      id: pid,
+      alias: "oc",
       modelsFetcher: { url: "https://models.dev/api.json", type: "opencode-free" },
     });
 
@@ -42,12 +43,14 @@ describe("fetchModelsFetcherIds", () => {
   });
 
   it("still supports array shapes", async () => {
+    const pid = "generic-array-test";
     globalThis.fetch.mockResolvedValue({
       ok: true,
       json: async () => [{ id: "model-a" }, { id: "model-b" }],
     });
 
-    const ids = await fetchModelsFetcherIds(cacheKey, {
+    const ids = await fetchModelsFetcherIds(pid, {
+      id: pid,
       modelsFetcher: { url: "https://x/models", type: "generic" },
     });
 

--- a/tests/unit/models-fetcher-dict.test.js
+++ b/tests/unit/models-fetcher-dict.test.js
@@ -1,0 +1,57 @@
+// Regression: opencode (and other noAuth modelsFetcher providers) pull models
+// from https://models.dev/api.json which returns a DICT shape:
+//   { "opencode": { "models": { "deepseek-v4-flash-free": {...}, ... } } }
+// The old parser only accepted array/`data.data`/array-`data.models`, so the
+// dict-shaped `data.models` produced `[]` → no oc/* models in /v1/models.
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { fetchModelsFetcherIds } from "../../src/sse/services/allowedModels.js";
+
+describe("fetchModelsFetcherIds", () => {
+  const originalFetch = globalThis.fetch;
+  let cacheKey;
+  beforeEach(() => {
+    cacheKey = `test-${Math.random()}`;
+    globalThis.fetch = vi.fn();
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("handles models.dev dict shape for opencode-free fetcher", async () => {
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        opencode: {
+          id: "opencode",
+          models: {
+            "deepseek-v4-flash-free": { id: "deepseek-v4-flash-free" },
+            "ling-3.0-flash-free": { id: "ling-3.0-flash-free" },
+            "claude-sonnet-4-6": { id: "claude-sonnet-4-6" },
+          },
+        },
+      }),
+    });
+
+    const ids = await fetchModelsFetcherIds(cacheKey, {
+      modelsFetcher: { url: "https://models.dev/api.json", type: "opencode-free" },
+    });
+
+    expect(ids).toContain("deepseek-v4-flash-free");
+    expect(ids).toContain("ling-3.0-flash-free");
+    expect(ids).not.toContain("claude-sonnet-4-6"); // non-free filtered
+  });
+
+  it("still supports array shapes", async () => {
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => [{ id: "model-a" }, { id: "model-b" }],
+    });
+
+    const ids = await fetchModelsFetcherIds(cacheKey, {
+      modelsFetcher: { url: "https://x/models", type: "generic" },
+    });
+
+    expect(ids).toContain("model-a");
+    expect(ids).toContain("model-b");
+  });
+});


### PR DESCRIPTION
## Summary
The Edit Access ACL dialog only rendered providers that had at least one `providerConnections` row. Free/noAuth providers like `opencode` (0 connections) were invisible, so API keys could not be granted access to them — even though `/api/providers` already returns all registered providers (including `opencode`, `mimo-free`, etc.).

## Change
`src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js`
- `buildProviderList(connections, nodes, registered)` now merges in every registered provider from the `/api/providers` `providers` array at count 0.
- Display name falls back to the registry `displayName` when there is no connection/node.
- Connection count is preserved for connected providers; noAuth/free providers appear with `0 conn`.

## Test Plan
- [x] `npx vitest run tests/unit/model-test-routing.test.js tests/unit/provider-custom-models.test.js tests/unit/handler-acl-enforcement.test.js --config tests/vitest.config.js` — 45 passed
- [x] `npm run build` (Next.js production build) — clean
- [x] Docker build `vansrouter:acl-noauth` — success
- [x] Verified in production DB: `opencode` has 0 connections while `mimo-free` has 1; both are `category: free` + `noAuth: true`. Before this change `opencode` was absent from the dialog; after it, registered noAuth providers are listed with `0 conn`.