### PR TITLE
feat(keys): add granular API key limits with persistence

### DIFF
--- a/open-sse/handlers/chatCore/requestDetail.js
+++ b/open-sse/handlers/chatCore/requestDetail.js
@@ -1,6 +1,7 @@
 import { saveRequestUsage, appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
 import { COLORS } from "../../utils/stream.js";
 import { canonicalizeUsage } from "../../utils/usageTracking.js";
+import { recordApiKeyUsage } from "@/lib/localDb.js";
 
 const OPTIONAL_PARAMS = [
   "temperature", "top_p", "top_k",
@@ -97,7 +98,15 @@ export function buildRequestDetail(base, overrides = {}) {
   };
 }
 
-export function saveUsageStats({ provider, model, tokens, connectionId, apiKey, endpoint, label = "USAGE" }) {
+export function saveUsageStats({ provider, model, tokens, connectionId, apiKey, apiKeyInfo, endpoint, label = "USAGE" }) {
+  if (apiKeyInfo) {
+    const inTok = tokens ? (tokens.input_tokens ?? tokens.prompt_tokens ?? 0) : 0;
+    const outTok = tokens ? (tokens.output_tokens ?? tokens.completion_tokens ?? 0) : 0;
+    const totalTokens = Math.max(0, inTok + outTok);
+    // Record usage to persistent SQLite repo (request already counted at admission = true)
+    recordApiKeyUsage(apiKeyInfo, totalTokens, { requestAlreadyCounted: true }).catch(() => {});
+  }
+
   if (!tokens || typeof tokens !== "object") return;
 
   const inTokens = tokens.input_tokens ?? tokens.prompt_tokens ?? 0;

--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
@@ -35,9 +35,20 @@ export default function APIPageClient() {
   const [editKinds, setEditKinds] = useState([]); // selected kinds
   const [editProviders, setEditProviders] = useState([]); // selected provider IDs
   const [editCombos, setEditCombos] = useState([]); // selected combo names
+  const [editModels, setEditModels] = useState(""); // comma or newline separated model patterns
+  const [editExpiresAt, setEditExpiresAt] = useState("");
+  const [editMaxTokens, setEditMaxTokens] = useState("");
+  const [editMaxTokensDaily, setEditMaxTokensDaily] = useState("");
+  const [editRpm, setEditRpm] = useState("");
+  const [editRph, setEditRph] = useState("");
+  const [editRpd, setEditRpd] = useState("");
+  const [editTokens5h, setEditTokens5h] = useState("");
+  const [editTokensWeekly, setEditTokensWeekly] = useState("");
+  const [editTokensMonthly, setEditTokensMonthly] = useState("");
   const [editKindsAll, setEditKindsAll] = useState(true); // null = all
   const [editProvidersAll, setEditProvidersAll] = useState(true);
   const [editCombosAll, setEditCombosAll] = useState(true);
+  const [editModelsAll, setEditModelsAll] = useState(true);
   const [editSaving, setEditSaving] = useState(false);
   const [providerList, setProviderList] = useState([]);
   const [aliasMap, setAliasMap] = useState({}); // alias → provider ID
@@ -455,14 +466,27 @@ export default function APIPageClient() {
   const handleOpenEditKey = async (key) => {
     setEditingKey(key);
     setEditName(key.name || "");
+    setEditExpiresAt(key.expiresAt ? key.expiresAt.slice(0, 16) : "");
+    setEditMaxTokens(key.maxTokens ?? "");
+    setEditMaxTokensDaily(key.maxTokensDaily ?? "");
+    setEditRpm(key.rpm ?? "");
+    setEditRph(key.rph ?? "");
+    setEditRpd(key.rpd ?? "");
+    setEditTokens5h(key.tokens5h ?? "");
+    setEditTokensWeekly(key.tokensWeekly ?? "");
+    setEditTokensMonthly(key.tokensMonthly ?? "");
+    
     const ap = key.allowedProviders;
     const ac = key.allowedCombos;
     const ak = key.allowedKinds;
+    const am = key.allowedModels;
     setEditProvidersAll(!ap);
     setEditCombosAll(!ac);
     setEditKindsAll(!ak);
+    setEditModelsAll(!am);
     setEditCombos(ac || []);
     setEditKinds(ak || []);
+    setEditModels(Array.isArray(am) ? am.join("\n") : "");
 
     // Resolve stored ACL provider values to provider IDs in our list
     // Stored values can be: full provider ID, prefix (e.g. "tr"), or alias (e.g. "oc", "qd", "kc")
@@ -491,11 +515,34 @@ export default function APIPageClient() {
     if (!editingKey) return;
     setEditSaving(true);
     try {
+      const parseNum = (s) => {
+        if (s === "" || s === null || s === undefined) return null;
+        const n = Number(s);
+        return Number.isInteger(n) && n >= 0 ? n : null;
+      };
+
+      const parsedModels = editModelsAll
+        ? null
+        : editModels
+            .split(/[\n,]/)
+            .map((m) => m.trim())
+            .filter(Boolean);
+
       const body = {
         name: editName.trim() || editingKey.name || "",
         allowedProviders: editProvidersAll ? null : editProviders,
         allowedCombos: editCombosAll ? null : editCombos,
         allowedKinds: editKindsAll ? null : editKinds,
+        allowedModels: parsedModels,
+        expiresAt: editExpiresAt ? new Date(editExpiresAt).toISOString() : null,
+        maxTokens: parseNum(editMaxTokens),
+        maxTokensDaily: parseNum(editMaxTokensDaily),
+        rpm: parseNum(editRpm),
+        rph: parseNum(editRph),
+        rpd: parseNum(editRpd),
+        tokens5h: parseNum(editTokens5h),
+        tokensWeekly: parseNum(editTokensWeekly),
+        tokensMonthly: parseNum(editTokensMonthly),
       };
       const res = await fetch(`/api/keys/${editingKey.id}`, {
         method: "PUT",
@@ -1521,8 +1568,53 @@ export default function APIPageClient() {
                    {key.isActive === false && (
                     <p className="text-xs text-orange-500 mt-1">Paused</p>
                   )}
+                  {key.expiresAt && (
+                    <p className="text-xs text-text-muted mt-1">
+                      Expires {new Date(key.expiresAt).toLocaleString()}
+                    </p>
+                  )}
+                  {/* Usage Badges */}
+                  {key.usage && (
+                    <div className="flex flex-wrap items-center gap-1.5 mt-1.5">
+                      {key.usage.rpm?.limit != null && (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface-2 text-text-muted font-mono">
+                          RPM: <span className="font-semibold text-text-main">{key.usage.rpm.used}</span>/{key.usage.rpm.limit}
+                        </span>
+                      )}
+                      {key.usage.rph?.limit != null && (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface-2 text-text-muted font-mono">
+                          RPH: <span className="font-semibold text-text-main">{key.usage.rph.used}</span>/{key.usage.rph.limit}
+                        </span>
+                      )}
+                      {key.usage.rpd?.limit != null && (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface-2 text-text-muted font-mono">
+                          RPD: <span className="font-semibold text-text-main">{key.usage.rpd.used}</span>/{key.usage.rpd.limit}
+                        </span>
+                      )}
+                      {key.usage.maxTokensDaily?.limit != null && (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface-2 text-text-muted font-mono">
+                          Daily Tokens: <span className="font-semibold text-text-main">{key.usage.maxTokensDaily.used?.toLocaleString()}</span>/{key.usage.maxTokensDaily.limit?.toLocaleString()}
+                        </span>
+                      )}
+                      {key.usage.tokens5h?.limit != null && (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface-2 text-text-muted font-mono">
+                          5H Tokens: <span className="font-semibold text-text-main">{key.usage.tokens5h.used?.toLocaleString()}</span>/{key.usage.tokens5h.limit?.toLocaleString()}
+                        </span>
+                      )}
+                      {key.usage.tokensWeekly?.limit != null && (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface-2 text-text-muted font-mono">
+                          Weekly Tokens: <span className="font-semibold text-text-main">{key.usage.tokensWeekly.used?.toLocaleString()}</span>/{key.usage.tokensWeekly.limit?.toLocaleString()}
+                        </span>
+                      )}
+                      {key.usage.tokensMonthly?.limit != null && (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface-2 text-text-muted font-mono">
+                          Monthly Tokens: <span className="font-semibold text-text-main">{key.usage.tokensMonthly.used?.toLocaleString()}</span>/{key.usage.tokensMonthly.limit?.toLocaleString()}
+                        </span>
+                      )}
+                    </div>
+                  )}
                    {/* ACL badges */}
-                  {(key.allowedProviders || key.allowedCombos || key.allowedKinds) && (
+                  {(key.allowedProviders || key.allowedCombos || key.allowedKinds || key.allowedModels) && (
                     <div className="flex flex-wrap gap-1 mt-1">
                       {key.allowedProviders && (
                         <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-500 dark:bg-blue-500/20" title={key.allowedProviders.join(", ")}>
@@ -1547,6 +1639,11 @@ export default function APIPageClient() {
                       {key.allowedKinds && (
                         <span className="text-[10px] px-1.5 py-0.5 rounded bg-green-500/10 text-green-500 dark:bg-green-500/20">
                           {key.allowedKinds.length === 0 ? "No kinds" : key.allowedKinds.join(", ")}
+                        </span>
+                      )}
+                      {key.allowedModels && (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-500 dark:bg-amber-500/20" title={key.allowedModels.join(", ")}>
+                          {key.allowedModels.length === 0 ? "No models" : `${key.allowedModels.length} models`}
                         </span>
                       )}
                     </div>
@@ -1769,6 +1866,79 @@ export default function APIPageClient() {
               </div>
             )}
             {editCombosAll && <p className="text-xs text-text-muted">This key can access all combos.</p>}
+          </div>
+
+          {/* Models Allowlist */}
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <label className="text-sm font-medium">Allowed Models / Patterns</label>
+              <label className="flex items-center gap-1.5 text-xs cursor-pointer">
+                <input type="checkbox" checked={editModelsAll} onChange={(e) => setEditModelsAll(e.target.checked)} />
+                <span className="text-text-muted">All allowed</span>
+              </label>
+            </div>
+            {!editModelsAll && (
+              <div className="space-y-1.5">
+                <textarea
+                  value={editModels}
+                  onChange={(e) => setEditModels(e.target.value)}
+                  placeholder="claude-3-5-sonnet-*\ngpt-4o\ncustom/*"
+                  rows={3}
+                  className="w-full text-xs font-mono p-2 rounded-lg border border-border bg-input focus:border-primary focus:outline-none"
+                />
+                <p className="text-[11px] text-text-muted">
+                  Enter model IDs or wildcard patterns (e.g. <code>claude-*</code>, <code>gemini-2.5*</code>), separated by commas or new lines.
+                </p>
+              </div>
+            )}
+            {editModelsAll && <p className="text-xs text-text-muted">This key can access all models.</p>}
+          </div>
+
+          {/* Usage & Rate Limits */}
+          <div className="border-t border-border-subtle pt-3">
+            <label className="text-sm font-medium mb-2 block">Rate & Token Limits (Optional)</label>
+            <div className="grid grid-cols-3 gap-2 mb-3">
+              <div>
+                <label className="text-[11px] text-text-muted block mb-0.5">RPM</label>
+                <Input value={editRpm} onChange={(e) => setEditRpm(e.target.value)} placeholder="e.g. 60" type="number" min="0" />
+              </div>
+              <div>
+                <label className="text-[11px] text-text-muted block mb-0.5">RPH</label>
+                <Input value={editRph} onChange={(e) => setEditRph(e.target.value)} placeholder="e.g. 1000" type="number" min="0" />
+              </div>
+              <div>
+                <label className="text-[11px] text-text-muted block mb-0.5">RPD</label>
+                <Input value={editRpd} onChange={(e) => setEditRpd(e.target.value)} placeholder="e.g. 5000" type="number" min="0" />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-2 mb-3">
+              <div>
+                <label className="text-[11px] text-text-muted block mb-0.5">Max Tokens / Req</label>
+                <Input value={editMaxTokens} onChange={(e) => setEditMaxTokens(e.target.value)} placeholder="e.g. 8192" type="number" min="0" />
+              </div>
+              <div>
+                <label className="text-[11px] text-text-muted block mb-0.5">Daily Token Limit</label>
+                <Input value={editMaxTokensDaily} onChange={(e) => setEditMaxTokensDaily(e.target.value)} placeholder="e.g. 500000" type="number" min="0" />
+              </div>
+            </div>
+            <div className="grid grid-cols-3 gap-2 mb-3">
+              <div>
+                <label className="text-[11px] text-text-muted block mb-0.5">5H Rolling Tokens</label>
+                <Input value={editTokens5h} onChange={(e) => setEditTokens5h(e.target.value)} placeholder="e.g. 100000" type="number" min="0" />
+              </div>
+              <div>
+                <label className="text-[11px] text-text-muted block mb-0.5">Weekly Tokens</label>
+                <Input value={editTokensWeekly} onChange={(e) => setEditTokensWeekly(e.target.value)} placeholder="e.g. 2000000" type="number" min="0" />
+              </div>
+              <div>
+                <label className="text-[11px] text-text-muted block mb-0.5">Monthly Tokens</label>
+                <Input value={editTokensMonthly} onChange={(e) => setEditTokensMonthly(e.target.value)} placeholder="e.g. 10000000" type="number" min="0" />
+              </div>
+            </div>
+            <div>
+              <label className="text-[11px] text-text-muted block mb-0.5">Expires At (Local Time)</label>
+              <Input value={editExpiresAt} onChange={(e) => setEditExpiresAt(e.target.value)} type="datetime-local" />
+            </div>
           </div>
 
           {/* ACL info */}

--- a/src/app/api/keys/[id]/route.js
+++ b/src/app/api/keys/[id]/route.js
@@ -1,5 +1,39 @@
 import { NextResponse } from "next/server";
-import { deleteApiKey, getApiKeyById, updateApiKey } from "@/lib/localDb";
+import { deleteApiKey, getApiKeyById, updateApiKey, getApiKeyUsageSnapshot } from "@/lib/localDb";
+
+function validateLimitsInput(body) {
+  const errors = [];
+  const intFields = ["maxTokens", "maxTokensDaily", "rpm", "rph", "rpd", "tokens5h", "tokensWeekly", "tokensMonthly"];
+
+  for (const field of intFields) {
+    if (field in body && body[field] !== null && body[field] !== undefined && body[field] !== "") {
+      const val = Number(body[field]);
+      if (!Number.isInteger(val) || val < 0) {
+        errors.push(`${field} must be a non-negative integer`);
+      }
+    }
+  }
+
+  if ("expiresAt" in body && body.expiresAt !== null && body.expiresAt !== undefined && body.expiresAt !== "") {
+    const d = new Date(body.expiresAt);
+    if (Number.isNaN(d.getTime())) {
+      errors.push("expiresAt must be a valid ISO date/timestamp");
+    }
+  }
+
+  const listFields = ["allowedProviders", "allowedCombos", "allowedKinds", "allowedModels"];
+  for (const field of listFields) {
+    if (field in body && body[field] !== null && body[field] !== undefined) {
+      if (!Array.isArray(body[field])) {
+        errors.push(`${field} must be an array of strings or null`);
+      } else if (body[field].some((item) => typeof item !== "string" || !item.trim())) {
+        errors.push(`${field} elements must be non-empty strings`);
+      }
+    }
+  }
+
+  return errors;
+}
 
 // GET /api/keys/[id] - Get single key
 export async function GET(request, { params }) {
@@ -9,7 +43,8 @@ export async function GET(request, { params }) {
     if (!key) {
       return NextResponse.json({ error: "Key not found" }, { status: 404 });
     }
-    return NextResponse.json({ key });
+    const usage = await getApiKeyUsageSnapshot(key);
+    return NextResponse.json({ key: { ...key, usage } });
   } catch (error) {
     console.log("Error fetching key:", error);
     return NextResponse.json({ error: "Failed to fetch key" }, { status: 500 });
@@ -21,32 +56,39 @@ export async function PUT(request, { params }) {
   try {
     const { id } = await params;
     const body = await request.json();
-    const { isActive, allowedProviders, allowedCombos, allowedKinds, name } = body;
 
     const existing = await getApiKeyById(id);
     if (!existing) {
       return NextResponse.json({ error: "Key not found" }, { status: 404 });
     }
 
-    const updateData = {};
-    if (isActive !== undefined) updateData.isActive = isActive;
-    // Name is optional on update; ignore blank/whitespace-only values.
-    if ("name" in body && typeof name === "string" && name.trim()) {
-      updateData.name = name.trim();
-    }
-    // null = all allowed, [] = none, [x] = specific. Only update if key present in body.
-    if ("allowedProviders" in body) {
-      updateData.allowedProviders = allowedProviders === null ? null : (Array.isArray(allowedProviders) ? allowedProviders : null);
-    }
-    if ("allowedCombos" in body) {
-      updateData.allowedCombos = allowedCombos === null ? null : (Array.isArray(allowedCombos) ? allowedCombos : null);
-    }
-    if ("allowedKinds" in body) {
-      updateData.allowedKinds = allowedKinds === null ? null : (Array.isArray(allowedKinds) ? allowedKinds : null);
+    const validationErrors = validateLimitsInput(body);
+    if (validationErrors.length > 0) {
+      return NextResponse.json({ error: validationErrors.join("; ") }, { status: 400 });
     }
 
+    const updateData = {};
+    if (body.isActive !== undefined) updateData.isActive = body.isActive;
+    if ("name" in body && typeof body.name === "string" && body.name.trim()) {
+      updateData.name = body.name.trim();
+    }
+    if ("allowedProviders" in body) updateData.allowedProviders = body.allowedProviders;
+    if ("allowedCombos" in body) updateData.allowedCombos = body.allowedCombos;
+    if ("allowedKinds" in body) updateData.allowedKinds = body.allowedKinds;
+    if ("allowedModels" in body) updateData.allowedModels = body.allowedModels;
+    if ("expiresAt" in body) updateData.expiresAt = body.expiresAt;
+    if ("maxTokens" in body) updateData.maxTokens = body.maxTokens;
+    if ("maxTokensDaily" in body) updateData.maxTokensDaily = body.maxTokensDaily;
+    if ("rpm" in body) updateData.rpm = body.rpm;
+    if ("rph" in body) updateData.rph = body.rph;
+    if ("rpd" in body) updateData.rpd = body.rpd;
+    if ("tokens5h" in body) updateData.tokens5h = body.tokens5h;
+    if ("tokensWeekly" in body) updateData.tokensWeekly = body.tokensWeekly;
+    if ("tokensMonthly" in body) updateData.tokensMonthly = body.tokensMonthly;
+
     const updated = await updateApiKey(id, updateData);
-    return NextResponse.json({ key: updated });
+    const usage = await getApiKeyUsageSnapshot(updated);
+    return NextResponse.json({ key: { ...updated, usage } });
   } catch (error) {
     console.log("Error updating key:", error);
     return NextResponse.json({ error: "Failed to update key" }, { status: 500 });

--- a/src/app/api/keys/route.js
+++ b/src/app/api/keys/route.js
@@ -1,14 +1,54 @@
 import { NextResponse } from "next/server";
-import { getApiKeys, createApiKey } from "@/lib/localDb";
+import { getApiKeys, createApiKey, getApiKeyUsageSnapshot } from "@/lib/localDb";
 import { getConsistentMachineId } from "@/shared/utils/machineId";
 
 export const dynamic = "force-dynamic";
 
-// GET /api/keys - List API keys
+function validateLimitsInput(body) {
+  const errors = [];
+  const intFields = ["maxTokens", "maxTokensDaily", "rpm", "rph", "rpd", "tokens5h", "tokensWeekly", "tokensMonthly"];
+
+  for (const field of intFields) {
+    if (field in body && body[field] !== null && body[field] !== undefined && body[field] !== "") {
+      const val = Number(body[field]);
+      if (!Number.isInteger(val) || val < 0) {
+        errors.push(`${field} must be a non-negative integer`);
+      }
+    }
+  }
+
+  if ("expiresAt" in body && body.expiresAt !== null && body.expiresAt !== undefined && body.expiresAt !== "") {
+    const d = new Date(body.expiresAt);
+    if (Number.isNaN(d.getTime())) {
+      errors.push("expiresAt must be a valid ISO date/timestamp");
+    }
+  }
+
+  const listFields = ["allowedProviders", "allowedCombos", "allowedKinds", "allowedModels"];
+  for (const field of listFields) {
+    if (field in body && body[field] !== null && body[field] !== undefined) {
+      if (!Array.isArray(body[field])) {
+        errors.push(`${field} must be an array of strings or null`);
+      } else if (body[field].some((item) => typeof item !== "string" || !item.trim())) {
+        errors.push(`${field} elements must be non-empty strings`);
+      }
+    }
+  }
+
+  return errors;
+}
+
+// GET /api/keys - List API keys with optional usage snapshots
 export async function GET() {
   try {
     const keys = await getApiKeys();
-    return NextResponse.json({ keys });
+    const keysWithUsage = await Promise.all(
+      keys.map(async (key) => {
+        const usage = await getApiKeyUsageSnapshot(key);
+        return { ...key, usage };
+      })
+    );
+    return NextResponse.json({ keys: keysWithUsage });
   } catch (error) {
     console.log("Error fetching keys:", error);
     return NextResponse.json({ error: "Failed to fetch keys" }, { status: 500 });
@@ -21,19 +61,23 @@ export async function POST(request) {
     const body = await request.json();
     const { name } = body;
 
-    if (!name) {
+    if (!name || typeof name !== "string" || !name.trim()) {
       return NextResponse.json({ error: "Name is required" }, { status: 400 });
+    }
+
+    const validationErrors = validateLimitsInput(body);
+    if (validationErrors.length > 0) {
+      return NextResponse.json({ error: validationErrors.join("; ") }, { status: 400 });
     }
 
     // Always get machineId from server
     const machineId = await getConsistentMachineId();
-    const apiKey = await createApiKey(name, machineId);
+    const apiKey = await createApiKey(name.trim(), machineId, body);
+    const usage = await getApiKeyUsageSnapshot(apiKey);
 
     return NextResponse.json({
-      key: apiKey.key,
-      name: apiKey.name,
-      id: apiKey.id,
-      machineId: apiKey.machineId,
+      ...apiKey,
+      usage,
     }, { status: 201 });
   } catch (error) {
     console.log("Error creating key:", error);

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -1,5 +1,5 @@
-import { isValidApiKey, extractApiKey, isProviderAllowed, isComboAllowed, isKindAllowed } from "@/sse/services/auth.js";
-import { getSettings } from "@/lib/localDb";
+import { isValidApiKey, extractApiKey, isProviderAllowed, isComboAllowed, isKindAllowed, isModelAllowed } from "@/sse/services/auth.js";
+import { getSettings, recordApiKeyUsage } from "@/lib/localDb";
 import { stripComboPrefix } from "open-sse/services/combo.js";
 import { buildModelsList } from "@/sse/services/allowedModels.js";
 import { capabilitiesFromServiceKind } from "open-sse/providers/capabilities.js";
@@ -59,6 +59,9 @@ export async function GET(request) {
     let data = await buildModelsList([LLM_KIND], { skipDynamicFetch });
 
     if (apiKeyInfo) {
+      // Record usage for /v1/models query
+      recordApiKeyUsage(apiKeyInfo, 0).catch(() => {});
+
       const allowedOwners = new Map();
       for (const model of data) {
         const isCombo = model.owned_by === "combo";
@@ -74,6 +77,7 @@ export async function GET(request) {
       }
       data = data.filter((model) => {
         if (!isKindAllowed(apiKeyInfo, model.kind || LLM_KIND)) return false;
+        if (!isModelAllowed(apiKeyInfo, model.id)) return false;
         const isCombo = model.owned_by === "combo";
         const key = isCombo
           ? `combo:${stripComboPrefix(model.id)}`

--- a/src/lib/db/index.js
+++ b/src/lib/db/index.js
@@ -40,6 +40,9 @@ export {
 export {
   getApiKeys, getApiKeyById, createApiKey, updateApiKey, deleteApiKey, validateApiKey,
 } from "./repos/apiKeysRepo.js";
+export {
+  checkApiKeyLimits, recordApiKeyUsage, getApiKeyUsageSnapshot,
+} from "./repos/apiKeyUsageRepo.js";
 
 // Combos
 export {

--- a/src/lib/db/migrations/005-add-api-key-limits-and-models.js
+++ b/src/lib/db/migrations/005-add-api-key-limits-and-models.js
@@ -1,0 +1,51 @@
+// Migration 005: add optional per-key usage/expiration limits & allowedModels.
+// All limit columns are nullable; null means unlimited / no restriction.
+export default {
+  version: 5,
+  name: "add-api-key-limits-and-models",
+  up(db) {
+    const rows = db.all("PRAGMA table_info(apiKeys)");
+    const columns = Array.isArray(rows) ? rows.map((row) => row.name) : [];
+    const add = (col, type) => {
+      if (!columns.includes(col)) {
+        db.exec(`ALTER TABLE apiKeys ADD COLUMN ${col} ${type}`);
+      }
+    };
+    add("allowedModels", "TEXT");  // JSON array of allowed model names/patterns
+    add("expiresAt", "TEXT");
+    add("maxTokens", "INTEGER");
+    add("maxTokensDaily", "INTEGER");
+    add("rpm", "INTEGER");        // requests per minute
+    add("rph", "INTEGER");        // requests per hour
+    add("rpd", "INTEGER");        // requests per day
+    add("tokens5h", "INTEGER");   // max tokens in rolling 5-hour window
+    add("tokensWeekly", "INTEGER");
+    add("tokensMonthly", "INTEGER");
+
+    // Create persistent usage tracking table for API keys
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS apiKeyUsageBuckets (
+        keyId TEXT NOT NULL,
+        bucketType TEXT NOT NULL,
+        bucketKey TEXT NOT NULL,
+        count INTEGER NOT NULL DEFAULT 0,
+        tokens INTEGER NOT NULL DEFAULT 0,
+        updatedAt INTEGER NOT NULL,
+        PRIMARY KEY (keyId, bucketType, bucketKey)
+      )
+    `);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_akub_key_type ON apiKeyUsageBuckets(keyId, bucketType)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_akub_updated ON apiKeyUsageBuckets(updatedAt)`);
+
+    // Create table for fine-grained 5h rolling token windows
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS apiKeyTokenEvents (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        keyId TEXT NOT NULL,
+        timestamp INTEGER NOT NULL,
+        tokens INTEGER NOT NULL
+      )
+    `);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_akte_key_ts ON apiKeyTokenEvents(keyId, timestamp)`);
+  },
+};

--- a/src/lib/db/migrations/index.js
+++ b/src/lib/db/migrations/index.js
@@ -5,10 +5,11 @@ import m001 from "./001-initial.js";
 import m002 from "./002-fix-empty-allowed-lists.js";
 import m003 from "./003-add-allowed-lists-columns.js";
 import m004 from "./004-add-request-details-apikey.js";
+import m005 from "./005-add-api-key-limits-and-models.js";
 import m007 from "./007-add-combo-context-length.js";
 import m008 from "./008-add-proxy-pool-fitness.js";
 
-export const MIGRATIONS = [m001, m002, m003, m004, m007, m008].sort((a, b) => a.version - b.version);
+export const MIGRATIONS = [m001, m002, m003, m004, m005, m007, m008].sort((a, b) => a.version - b.version);
 
 export function latestVersion() {
   return MIGRATIONS.length ? MIGRATIONS[MIGRATIONS.length - 1].version : 0;

--- a/src/lib/db/repos/apiKeyUsageRepo.js
+++ b/src/lib/db/repos/apiKeyUsageRepo.js
@@ -1,0 +1,325 @@
+import { getAdapter } from "../driver.js";
+
+// Time key generators using UTC for cross-timezone consistency
+function getMinuteKey(ts = Date.now()) {
+  const d = new Date(ts);
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}T${String(d.getUTCHours()).padStart(2, "0")}:${String(d.getUTCMinutes()).padStart(2, "0")}`;
+}
+
+function getHourKey(ts = Date.now()) {
+  const d = new Date(ts);
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}T${String(d.getUTCHours()).padStart(2, "0")}`;
+}
+
+function getDateKey(ts = Date.now()) {
+  const d = new Date(ts);
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}`;
+}
+
+function getWeekKey(ts = Date.now()) {
+  const d = new Date(ts);
+  const day = d.getUTCDay();
+  const diff = d.getUTCDate() - day; // Sunday of this UTC week
+  const start = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), diff));
+  return `${start.getUTCFullYear()}-${String(start.getUTCMonth() + 1).padStart(2, "0")}-${String(start.getUTCDate()).padStart(2, "0")}`;
+}
+
+function getMonthKey(ts = Date.now()) {
+  const d = new Date(ts);
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+/**
+ * Check limits and optionally reserve admission in a single atomic transaction.
+ * @param {object} apiKeyInfo - key row from apiKeysRepo
+ * @param {number} estimatedTokens - rough estimate of prompt tokens (or 0)
+ * @param {boolean} reserveRequest - if true, atomics increment request counter at admission
+ * @returns {Promise<{ allowed: boolean, reason?: string, retryAfterMs?: number }>}
+ */
+export async function checkApiKeyLimits(apiKeyInfo, estimatedTokens = 0, reserveRequest = false) {
+  if (!apiKeyInfo) return { allowed: true };
+
+  // Expiration check
+  if (apiKeyInfo.expiresAt) {
+    const expiryTs = new Date(apiKeyInfo.expiresAt).getTime();
+    if (!Number.isNaN(expiryTs) && Date.now() >= expiryTs) {
+      return { allowed: false, reason: `API key expired on ${apiKeyInfo.expiresAt}` };
+    }
+  }
+
+  const hasAnyLimit = (
+    apiKeyInfo.rpm != null ||
+    apiKeyInfo.rph != null ||
+    apiKeyInfo.rpd != null ||
+    apiKeyInfo.maxTokens != null ||
+    apiKeyInfo.maxTokensDaily != null ||
+    apiKeyInfo.tokens5h != null ||
+    apiKeyInfo.tokensWeekly != null ||
+    apiKeyInfo.tokensMonthly != null
+  );
+
+  if (!hasAnyLimit) return { allowed: true };
+
+  const db = await getAdapter();
+  const keyId = apiKeyInfo.id;
+  const now = Date.now();
+  const estTokens = Math.max(0, Number(estimatedTokens) || 0);
+
+  // Per-request token cap check
+  if (apiKeyInfo.maxTokens != null && estTokens > apiKeyInfo.maxTokens) {
+    return { allowed: false, reason: `Estimated token count (${estTokens}) exceeds maximum per-request limit (${apiKeyInfo.maxTokens})` };
+  }
+
+  let result = { allowed: true };
+
+  db.transaction(() => {
+    // 1. Check RPM
+    if (apiKeyInfo.rpm != null) {
+      const minKey = getMinuteKey(now);
+      const row = db.get(
+        `SELECT count FROM apiKeyUsageBuckets WHERE keyId = ? AND bucketType = 'rpm' AND bucketKey = ?`,
+        [keyId, minKey]
+      );
+      const current = row?.count || 0;
+      if (current + 1 > apiKeyInfo.rpm) {
+        const nextMin = (Math.floor(now / 60000) + 1) * 60000;
+        result = {
+          allowed: false,
+          reason: `Rate limit exceeded: ${apiKeyInfo.rpm} requests per minute`,
+          retryAfterMs: Math.max(1000, nextMin - now),
+        };
+        return;
+      }
+    }
+
+    // 2. Check RPH
+    if (apiKeyInfo.rph != null) {
+      const hourKey = getHourKey(now);
+      const row = db.get(
+        `SELECT count FROM apiKeyUsageBuckets WHERE keyId = ? AND bucketType = 'rph' AND bucketKey = ?`,
+        [keyId, hourKey]
+      );
+      const current = row?.count || 0;
+      if (current + 1 > apiKeyInfo.rph) {
+        const nextHour = (Math.floor(now / 3600000) + 1) * 3600000;
+        result = {
+          allowed: false,
+          reason: `Rate limit exceeded: ${apiKeyInfo.rph} requests per hour`,
+          retryAfterMs: Math.max(1000, nextHour - now),
+        };
+        return;
+      }
+    }
+
+    // 3. Check RPD
+    if (apiKeyInfo.rpd != null) {
+      const dateKey = getDateKey(now);
+      const row = db.get(
+        `SELECT count FROM apiKeyUsageBuckets WHERE keyId = ? AND bucketType = 'rpd' AND bucketKey = ?`,
+        [keyId, dateKey]
+      );
+      const current = row?.count || 0;
+      if (current + 1 > apiKeyInfo.rpd) {
+        const nextDay = (Math.floor(now / 86400000) + 1) * 86400000;
+        result = {
+          allowed: false,
+          reason: `Rate limit exceeded: ${apiKeyInfo.rpd} requests per day`,
+          retryAfterMs: Math.max(1000, nextDay - now),
+        };
+        return;
+      }
+    }
+
+    // 4. Check Daily Tokens
+    if (apiKeyInfo.maxTokensDaily != null) {
+      const dateKey = getDateKey(now);
+      const row = db.get(
+        `SELECT tokens FROM apiKeyUsageBuckets WHERE keyId = ? AND bucketType = 'tokensDaily' AND bucketKey = ?`,
+        [keyId, dateKey]
+      );
+      const used = row?.tokens || 0;
+      if (used + estTokens > apiKeyInfo.maxTokensDaily) {
+        result = { allowed: false, reason: `Daily token limit exceeded: ${apiKeyInfo.maxTokensDaily}` };
+        return;
+      }
+    }
+
+    // 5. Check 5-Hour Tokens
+    if (apiKeyInfo.tokens5h != null) {
+      const windowStart = now - 5 * 3600000;
+      const row = db.get(
+        `SELECT SUM(tokens) as totalTokens FROM apiKeyTokenEvents WHERE keyId = ? AND timestamp >= ?`,
+        [keyId, windowStart]
+      );
+      const used = row?.totalTokens || 0;
+      if (used + estTokens > apiKeyInfo.tokens5h) {
+        result = { allowed: false, reason: `5-hour rolling token window exceeded: ${apiKeyInfo.tokens5h}` };
+        return;
+      }
+    }
+
+    // 6. Check Weekly Tokens
+    if (apiKeyInfo.tokensWeekly != null) {
+      const weekKey = getWeekKey(now);
+      const row = db.get(
+        `SELECT tokens FROM apiKeyUsageBuckets WHERE keyId = ? AND bucketType = 'tokensWeekly' AND bucketKey = ?`,
+        [keyId, weekKey]
+      );
+      const used = row?.tokens || 0;
+      if (used + estTokens > apiKeyInfo.tokensWeekly) {
+        result = { allowed: false, reason: `Weekly token limit exceeded: ${apiKeyInfo.tokensWeekly}` };
+        return;
+      }
+    }
+
+    // 7. Check Monthly Tokens
+    if (apiKeyInfo.tokensMonthly != null) {
+      const monthKey = getMonthKey(now);
+      const row = db.get(
+        `SELECT tokens FROM apiKeyUsageBuckets WHERE keyId = ? AND bucketType = 'tokensMonthly' AND bucketKey = ?`,
+        [keyId, monthKey]
+      );
+      const used = row?.tokens || 0;
+      if (used + estTokens > apiKeyInfo.tokensMonthly) {
+        result = { allowed: false, reason: `Monthly token limit exceeded: ${apiKeyInfo.tokensMonthly}` };
+        return;
+      }
+    }
+
+    // If reserveRequest is true and admission passes, reserve 1 request immediately
+    if (reserveRequest) {
+      const minKey = getMinuteKey(now);
+      const hourKey = getHourKey(now);
+      const dateKey = getDateKey(now);
+
+      const bump = (type, key) => {
+        db.run(
+          `INSERT INTO apiKeyUsageBuckets(keyId, bucketType, bucketKey, count, tokens, updatedAt)
+           VALUES (?, ?, ?, 1, 0, ?)
+           ON CONFLICT(keyId, bucketType, bucketKey) DO UPDATE SET
+             count = count + 1,
+             updatedAt = excluded.updatedAt`,
+          [keyId, type, key, now]
+        );
+      };
+
+      bump("rpm", minKey);
+      bump("rph", hourKey);
+      bump("rpd", dateKey);
+    }
+  });
+
+  return result;
+}
+
+/**
+ * Record API key usage atomically into SQLite.
+ * Always records request count (unless already reserved) and token consumption.
+ * @param {object} apiKeyInfo
+ * @param {number} tokensUsed - prompt + completion tokens
+ * @param {object} options - { requestAlreadyCounted: boolean }
+ */
+export async function recordApiKeyUsage(apiKeyInfo, tokensUsed = 0, options = {}) {
+  if (!apiKeyInfo) return;
+  const db = await getAdapter();
+  const keyId = apiKeyInfo.id;
+  const now = Date.now();
+  const tokens = Math.max(0, Number(tokensUsed) || 0);
+  const incReq = options?.requestAlreadyCounted ? 0 : 1;
+
+  const minKey = getMinuteKey(now);
+  const hourKey = getHourKey(now);
+  const dateKey = getDateKey(now);
+  const weekKey = getWeekKey(now);
+  const monthKey = getMonthKey(now);
+
+  db.transaction(() => {
+    // 1. Request rate buckets
+    if (incReq > 0) {
+      const bumpReq = (type, key) => {
+        db.run(
+          `INSERT INTO apiKeyUsageBuckets(keyId, bucketType, bucketKey, count, tokens, updatedAt)
+           VALUES (?, ?, ?, 1, 0, ?)
+           ON CONFLICT(keyId, bucketType, bucketKey) DO UPDATE SET
+             count = count + 1,
+             updatedAt = excluded.updatedAt`,
+          [keyId, type, key, now]
+        );
+      };
+      bumpReq("rpm", minKey);
+      bumpReq("rph", hourKey);
+      bumpReq("rpd", dateKey);
+    }
+
+    // 2. Token buckets & events
+    if (tokens > 0) {
+      const bumpTokens = (type, key) => {
+        db.run(
+          `INSERT INTO apiKeyUsageBuckets(keyId, bucketType, bucketKey, count, tokens, updatedAt)
+           VALUES (?, ?, ?, 0, ?, ?)
+           ON CONFLICT(keyId, bucketType, bucketKey) DO UPDATE SET
+             tokens = tokens + excluded.tokens,
+             updatedAt = excluded.updatedAt`,
+          [keyId, type, key, tokens, now]
+        );
+      };
+
+      bumpTokens("tokensDaily", dateKey);
+      bumpTokens("tokensWeekly", weekKey);
+      bumpTokens("tokensMonthly", monthKey);
+
+      // Insert 5h event
+      db.run(
+        `INSERT INTO apiKeyTokenEvents(keyId, timestamp, tokens) VALUES(?, ?, ?)`,
+        [keyId, now, tokens]
+      );
+
+      // Clean up old token events older than 6 hours
+      const pruneCutoff = now - 6 * 3600000;
+      db.run(`DELETE FROM apiKeyTokenEvents WHERE timestamp < ?`, [pruneCutoff]);
+    }
+  });
+}
+
+/**
+ * Get current usage snapshot for an API key (for Dashboard badges & limits display).
+ * @param {object} apiKeyInfo
+ */
+export async function getApiKeyUsageSnapshot(apiKeyInfo) {
+  if (!apiKeyInfo) return null;
+  const db = await getAdapter();
+  const keyId = apiKeyInfo.id;
+  const now = Date.now();
+
+  const minKey = getMinuteKey(now);
+  const hourKey = getHourKey(now);
+  const dateKey = getDateKey(now);
+  const weekKey = getWeekKey(now);
+  const monthKey = getMonthKey(now);
+
+  const getBucketVal = (type, key, field) => {
+    const row = db.get(
+      `SELECT ${field} FROM apiKeyUsageBuckets WHERE keyId = ? AND bucketType = ? AND bucketKey = ?`,
+      [keyId, type, key]
+    );
+    return row ? row[field] : 0;
+  };
+
+  const window5hStart = now - 5 * 3600000;
+  const row5h = db.get(
+    `SELECT SUM(tokens) as total FROM apiKeyTokenEvents WHERE keyId = ? AND timestamp >= ?`,
+    [keyId, window5hStart]
+  );
+  const used5h = row5h?.total || 0;
+
+  return {
+    rpm: { limit: apiKeyInfo.rpm ?? null, used: getBucketVal("rpm", minKey, "count") },
+    rph: { limit: apiKeyInfo.rph ?? null, used: getBucketVal("rph", hourKey, "count") },
+    rpd: { limit: apiKeyInfo.rpd ?? null, used: getBucketVal("rpd", dateKey, "count") },
+    tokens5h: { limit: apiKeyInfo.tokens5h ?? null, used: used5h },
+    maxTokens: { limit: apiKeyInfo.maxTokens ?? null, used: null },
+    maxTokensDaily: { limit: apiKeyInfo.maxTokensDaily ?? null, used: getBucketVal("tokensDaily", dateKey, "tokens") },
+    tokensWeekly: { limit: apiKeyInfo.tokensWeekly ?? null, used: getBucketVal("tokensWeekly", weekKey, "tokens") },
+    tokensMonthly: { limit: apiKeyInfo.tokensMonthly ?? null, used: getBucketVal("tokensMonthly", monthKey, "tokens") },
+  };
+}

--- a/src/lib/db/repos/apiKeysRepo.js
+++ b/src/lib/db/repos/apiKeysRepo.js
@@ -14,6 +14,19 @@ function serializePermList(val) {
   return JSON.stringify(Array.isArray(val) ? val : []);
 }
 
+function parseLimitInt(val) {
+  if (val === null || val === undefined || val === "") return null;
+  const n = parseInt(val, 10);
+  return Number.isNaN(n) || n < 0 ? null : n;
+}
+
+function parseExpiresAt(val) {
+  if (val === null || val === undefined || val === "") return null;
+  if (typeof val !== "string") return null;
+  const d = new Date(val);
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
+}
+
 function rowToKey(row) {
   if (!row) return null;
   return {
@@ -26,6 +39,16 @@ function rowToKey(row) {
     allowedProviders: parsePermList(row.allowedProviders),
     allowedCombos: parsePermList(row.allowedCombos),
     allowedKinds: parsePermList(row.allowedKinds),
+    allowedModels: parsePermList(row.allowedModels),
+    expiresAt: row.expiresAt || null,
+    maxTokens: parseLimitInt(row.maxTokens),
+    maxTokensDaily: parseLimitInt(row.maxTokensDaily),
+    rpm: parseLimitInt(row.rpm),
+    rph: parseLimitInt(row.rph),
+    rpd: parseLimitInt(row.rpd),
+    tokens5h: parseLimitInt(row.tokens5h),
+    tokensWeekly: parseLimitInt(row.tokensWeekly),
+    tokensMonthly: parseLimitInt(row.tokensMonthly),
   };
 }
 
@@ -41,7 +64,7 @@ export async function getApiKeyById(id) {
   return rowToKey(row);
 }
 
-export async function createApiKey(name, machineId) {
+export async function createApiKey(name, machineId, limits = {}) {
   if (!machineId) throw new Error("machineId is required");
   const [db, { generateApiKeyWithMachine }] = await Promise.all([
     getAdapter(),
@@ -55,13 +78,47 @@ export async function createApiKey(name, machineId) {
     machineId,
     isActive: true,
     createdAt: new Date().toISOString(),
-    allowedProviders: null,
-    allowedCombos: null,
-    allowedKinds: null,
+    allowedProviders: limits.allowedProviders !== undefined ? limits.allowedProviders : null,
+    allowedCombos: limits.allowedCombos !== undefined ? limits.allowedCombos : null,
+    allowedKinds: limits.allowedKinds !== undefined ? limits.allowedKinds : null,
+    allowedModels: limits.allowedModels !== undefined ? limits.allowedModels : null,
+    expiresAt: parseExpiresAt(limits.expiresAt),
+    maxTokens: parseLimitInt(limits.maxTokens),
+    maxTokensDaily: parseLimitInt(limits.maxTokensDaily),
+    rpm: parseLimitInt(limits.rpm),
+    rph: parseLimitInt(limits.rph),
+    rpd: parseLimitInt(limits.rpd),
+    tokens5h: parseLimitInt(limits.tokens5h),
+    tokensWeekly: parseLimitInt(limits.tokensWeekly),
+    tokensMonthly: parseLimitInt(limits.tokensMonthly),
   };
   db.run(
-    `INSERT INTO apiKeys(id, key, name, machineId, isActive, createdAt, allowedProviders, allowedCombos, allowedKinds) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    [apiKey.id, apiKey.key, apiKey.name, apiKey.machineId, 1, apiKey.createdAt, null, null, null]
+    `INSERT INTO apiKeys(
+       id, key, name, machineId, isActive, createdAt,
+       allowedProviders, allowedCombos, allowedKinds, allowedModels,
+       expiresAt, maxTokens, maxTokensDaily, rpm, rph, rpd, tokens5h, tokensWeekly, tokensMonthly
+     ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      apiKey.id,
+      apiKey.key,
+      apiKey.name,
+      apiKey.machineId,
+      1,
+      apiKey.createdAt,
+      serializePermList(apiKey.allowedProviders),
+      serializePermList(apiKey.allowedCombos),
+      serializePermList(apiKey.allowedKinds),
+      serializePermList(apiKey.allowedModels),
+      apiKey.expiresAt,
+      apiKey.maxTokens,
+      apiKey.maxTokensDaily,
+      apiKey.rpm,
+      apiKey.rph,
+      apiKey.rpd,
+      apiKey.tokens5h,
+      apiKey.tokensWeekly,
+      apiKey.tokensMonthly,
+    ]
   );
   return apiKey;
 }
@@ -73,15 +130,30 @@ export async function updateApiKey(id, data) {
     const row = db.get(`SELECT * FROM apiKeys WHERE id = ?`, [id]);
     if (!row) return;
     const current = rowToKey(row);
-    // Merge: only override fields explicitly present in data
     const merged = { ...current };
     if (data.isActive !== undefined) merged.isActive = data.isActive;
     if (data.name !== undefined) merged.name = data.name;
     if ("allowedProviders" in data) merged.allowedProviders = data.allowedProviders;
     if ("allowedCombos" in data) merged.allowedCombos = data.allowedCombos;
     if ("allowedKinds" in data) merged.allowedKinds = data.allowedKinds;
+    if ("allowedModels" in data) merged.allowedModels = data.allowedModels;
+    if ("expiresAt" in data) merged.expiresAt = parseExpiresAt(data.expiresAt);
+    if ("maxTokens" in data) merged.maxTokens = parseLimitInt(data.maxTokens);
+    if ("maxTokensDaily" in data) merged.maxTokensDaily = parseLimitInt(data.maxTokensDaily);
+    if ("rpm" in data) merged.rpm = parseLimitInt(data.rpm);
+    if ("rph" in data) merged.rph = parseLimitInt(data.rph);
+    if ("rpd" in data) merged.rpd = parseLimitInt(data.rpd);
+    if ("tokens5h" in data) merged.tokens5h = parseLimitInt(data.tokens5h);
+    if ("tokensWeekly" in data) merged.tokensWeekly = parseLimitInt(data.tokensWeekly);
+    if ("tokensMonthly" in data) merged.tokensMonthly = parseLimitInt(data.tokensMonthly);
+
     db.run(
-      `UPDATE apiKeys SET key = ?, name = ?, machineId = ?, isActive = ?, allowedProviders = ?, allowedCombos = ?, allowedKinds = ? WHERE id = ?`,
+      `UPDATE apiKeys SET
+         key = ?, name = ?, machineId = ?, isActive = ?,
+         allowedProviders = ?, allowedCombos = ?, allowedKinds = ?, allowedModels = ?,
+         expiresAt = ?, maxTokens = ?, maxTokensDaily = ?, rpm = ?, rph = ?, rpd = ?,
+         tokens5h = ?, tokensWeekly = ?, tokensMonthly = ?
+       WHERE id = ?`,
       [
         merged.key,
         merged.name,
@@ -90,6 +162,16 @@ export async function updateApiKey(id, data) {
         serializePermList(merged.allowedProviders),
         serializePermList(merged.allowedCombos),
         serializePermList(merged.allowedKinds),
+        serializePermList(merged.allowedModels),
+        merged.expiresAt,
+        merged.maxTokens,
+        merged.maxTokensDaily,
+        merged.rpm,
+        merged.rph,
+        merged.rpd,
+        merged.tokens5h,
+        merged.tokensWeekly,
+        merged.tokensMonthly,
         id,
       ]
     );
@@ -100,13 +182,26 @@ export async function updateApiKey(id, data) {
 
 export async function deleteApiKey(id) {
   const db = await getAdapter();
-  const res = db.run(`DELETE FROM apiKeys WHERE id = ?`, [id]);
-  return (res?.changes ?? 0) > 0;
+  let deleted = false;
+  db.transaction(() => {
+    const res = db.run(`DELETE FROM apiKeys WHERE id = ?`, [id]);
+    db.run(`DELETE FROM apiKeyUsageBuckets WHERE keyId = ?`, [id]);
+    db.run(`DELETE FROM apiKeyTokenEvents WHERE keyId = ?`, [id]);
+    deleted = (res?.changes ?? 0) > 0;
+  });
+  return deleted;
 }
 
 export async function validateApiKey(key) {
   const db = await getAdapter();
   const row = db.get(`SELECT * FROM apiKeys WHERE key = ?`, [key]);
-  if (!row || row.isActive !== 1 && row.isActive !== true) return null;
-  return rowToKey(row);
+  if (!row || (row.isActive !== 1 && row.isActive !== true)) return null;
+  const keyInfo = rowToKey(row);
+  if (keyInfo.expiresAt) {
+    const expiryTs = new Date(keyInfo.expiresAt).getTime();
+    if (!Number.isNaN(expiryTs) && Date.now() >= expiryTs) {
+      return null;
+    }
+  }
+  return keyInfo;
 }

--- a/src/lib/db/schema.js
+++ b/src/lib/db/schema.js
@@ -3,7 +3,7 @@
 // pre-change safety backup in migrate.js: when the stored version is lower,
 // one lightweight DB backup is taken before applying schema changes. Forgetting
 // to bump only skips that backup — it does NOT break the additive auto-sync.
-export const SCHEMA_VERSION = 8;
+export const SCHEMA_VERSION = 9;
 
 export const PRAGMA_SQL = `
 PRAGMA journal_mode = WAL;
@@ -99,8 +99,47 @@ export const TABLES = {
       machineId: "TEXT",
       isActive: "INTEGER DEFAULT 1",
       createdAt: "TEXT NOT NULL",
+      allowedProviders: "TEXT",
+      allowedCombos: "TEXT",
+      allowedKinds: "TEXT",
+      allowedModels: "TEXT",
+      expiresAt: "TEXT",
+      maxTokens: "INTEGER",
+      maxTokensDaily: "INTEGER",
+      rpm: "INTEGER",
+      rph: "INTEGER",
+      rpd: "INTEGER",
+      tokens5h: "INTEGER",
+      tokensWeekly: "INTEGER",
+      tokensMonthly: "INTEGER",
     },
     indexes: ["CREATE INDEX IF NOT EXISTS idx_ak_key ON apiKeys(key)"],
+  },
+  apiKeyUsageBuckets: {
+    columns: {
+      keyId: "TEXT NOT NULL",
+      bucketType: "TEXT NOT NULL",
+      bucketKey: "TEXT NOT NULL",
+      count: "INTEGER NOT NULL DEFAULT 0",
+      tokens: "INTEGER NOT NULL DEFAULT 0",
+      updatedAt: "INTEGER NOT NULL",
+    },
+    primaryKey: "PRIMARY KEY (keyId, bucketType, bucketKey)",
+    indexes: [
+      "CREATE INDEX IF NOT EXISTS idx_akub_key_type ON apiKeyUsageBuckets(keyId, bucketType)",
+      "CREATE INDEX IF NOT EXISTS idx_akub_updated ON apiKeyUsageBuckets(updatedAt)",
+    ],
+  },
+  apiKeyTokenEvents: {
+    columns: {
+      id: "INTEGER PRIMARY KEY AUTOINCREMENT",
+      keyId: "TEXT NOT NULL",
+      timestamp: "INTEGER NOT NULL",
+      tokens: "INTEGER NOT NULL",
+    },
+    indexes: [
+      "CREATE INDEX IF NOT EXISTS idx_akte_key_ts ON apiKeyTokenEvents(keyId, timestamp)",
+    ],
   },
   combos: {
     columns: {

--- a/src/lib/localDb.js
+++ b/src/lib/localDb.js
@@ -13,6 +13,7 @@ export {
   listProxyPoolFitness, upsertProxyPoolFitness,
   deleteProxyPoolFitness, clearProxyPoolFitness, deleteProxyPoolFitnessByPool,
   getApiKeys, getApiKeyById, createApiKey, updateApiKey, deleteApiKey, validateApiKey,
+  checkApiKeyLimits, recordApiKeyUsage, getApiKeyUsageSnapshot,
   getCombos, getComboById, getComboByName,
   createCombo, updateCombo, deleteCombo,
   getModelAliases, setModelAlias, deleteModelAlias,

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -11,7 +11,6 @@ import {
   isKindAllowed,
   isTrustedInternalRequest,
 } from "../services/auth.js";
-import { handleAntigravityQuotaError } from "../services/antigravityQuota.js";
 import {
   isKimchiQuotaExhausted,
   buildKimchiQuotaExhaustedUpdate,
@@ -23,6 +22,8 @@ import {
   recordProviderFailure,
   clearProviderFailure,
 } from "open-sse/services/accountFallback.js";
+import { checkApiKeyLimits } from "@/lib/localDb.js";
+import { handleAntigravityQuotaError } from "../services/antigravityQuota.js";
 import {
   acquire as acquireAccountSemaphore,
   resolveAccountSemaphoreKey,
@@ -121,6 +122,27 @@ export async function handleChat(request, clientRawRequest = null) {
     if (!apiKeyInfo) {
       log.warn("AUTH", "Invalid API key (requireApiKey=true)");
       return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
+    }
+  }
+
+  // Enforce per-key usage limits (applies even when requireApiKey is false but a key was supplied)
+  if (apiKeyInfo) {
+    const estimatedTokens = Math.max(0, Number(body.max_tokens || body.max_completion_tokens) || (msgCount * 50));
+    const limitCheck = await checkApiKeyLimits(apiKeyInfo, estimatedTokens, true);
+    if (!limitCheck.allowed) {
+      log.warn("AUTH", `API key limit exceeded: ${limitCheck.reason}`);
+      const retryAfter = limitCheck.retryAfterMs ? Math.ceil(limitCheck.retryAfterMs / 1000).toString() : undefined;
+      const resBody = JSON.stringify({
+        error: { message: limitCheck.reason, type: "rate_limit_error", code: "rate_limit_exceeded" },
+      });
+      return new Response(resBody, {
+        status: HTTP_STATUS.RATE_LIMITED,
+        headers: {
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+          ...(retryAfter ? { "Retry-After": retryAfter } : {}),
+        },
+      });
     }
   }
 

--- a/src/sse/services/allowedModels.js
+++ b/src/sse/services/allowedModels.js
@@ -695,8 +695,26 @@ export function invalidateAllowedModelsCache() {
 }
 
 export async function isModelAllowed(modelStr, apiKeyInfo = null) {
-  if (!apiKeyInfo) return true;
   const allowed = await getAllowedModelIds();
-  return allowed.has(modelStr);
+  if (!allowed.has(modelStr)) return false;
+  if (!apiKeyInfo) return true;
+
+  // Check per-key allowedModels if configured
+  const keyAllowedModels = apiKeyInfo.allowedModels;
+  if (keyAllowedModels === null || keyAllowedModels === undefined) return true;
+  if (!Array.isArray(keyAllowedModels) || keyAllowedModels.length === 0) return false;
+
+  const target = String(modelStr).trim().toLowerCase();
+  for (const item of keyAllowedModels) {
+    if (!item) continue;
+    const pat = String(item).trim().toLowerCase();
+    if (pat === target) return true;
+    if (pat.includes("*")) {
+      const escaped = pat.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+      const regex = new RegExp(`^${escaped}$`);
+      if (regex.test(target)) return true;
+    }
+  }
+  return false;
 }
 

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -490,3 +490,28 @@ export function isKindAllowed(apiKeyInfo, kind) {
   return allowed.includes(kind);
 }
 
+/**
+ * Check if a model name is allowed for a given API key.
+ * null = all allowed (default). [] = none allowed. [x] = only x.
+ * Supports exact match, model alias match, or wildcard glob match (e.g. "claude-*", "gpt-4*").
+ */
+export function isModelAllowed(apiKeyInfo, modelName) {
+  if (!apiKeyInfo) return true;
+  const allowed = apiKeyInfo.allowedModels;
+  if (allowed === null || allowed === undefined) return true; // null = all
+  if (!Array.isArray(allowed) || allowed.length === 0) return false; // [] = none
+  if (!modelName) return false;
+
+  const target = String(modelName).trim().toLowerCase();
+  for (const item of allowed) {
+    if (!item) continue;
+    const pat = String(item).trim().toLowerCase();
+    if (pat === target) return true;
+    if (pat.includes("*")) {
+      const escaped = pat.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+      const regex = new RegExp(`^${escaped}$`);
+      if (regex.test(target)) return true;
+    }
+  }
+  return false;
+}

--- a/tests/unit/api-key-limits-persistence.test.js
+++ b/tests/unit/api-key-limits-persistence.test.js
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { getAdapter } from "@/lib/db/driver.js";
+import {
+  createApiKey,
+  getApiKeyById,
+  updateApiKey,
+  deleteApiKey,
+  validateApiKey,
+} from "@/lib/db/repos/apiKeysRepo.js";
+import {
+  checkApiKeyLimits,
+  recordApiKeyUsage,
+  getApiKeyUsageSnapshot,
+} from "@/lib/db/repos/apiKeyUsageRepo.js";
+import { isModelAllowed } from "@/sse/services/auth.js";
+
+describe("API Key Limits & Usage Repository (SQLite-backed)", () => {
+  let db;
+
+  beforeEach(async () => {
+    db = await getAdapter();
+    db.run("DELETE FROM apiKeys");
+    db.run("DELETE FROM apiKeyUsageBuckets");
+    db.run("DELETE FROM apiKeyTokenEvents");
+  });
+
+  it("creates and retrieves an API key with limits and allowedModels", async () => {
+    const key = await createApiKey("Test Key", "machine-123", {
+      rpm: 10,
+      rph: 100,
+      rpd: 500,
+      maxTokens: 4096,
+      maxTokensDaily: 50000,
+      tokens5h: 20000,
+      tokensWeekly: 200000,
+      tokensMonthly: 1000000,
+      allowedModels: ["claude-3-5-sonnet-*", "gpt-4o"],
+      expiresAt: new Date(Date.now() + 86400000).toISOString(),
+    });
+
+    expect(key.name).toBe("Test Key");
+    expect(key.rpm).toBe(10);
+    expect(key.rph).toBe(100);
+    expect(key.rpd).toBe(500);
+    expect(key.maxTokens).toBe(4096);
+    expect(key.maxTokensDaily).toBe(50000);
+    expect(key.tokens5h).toBe(20000);
+    expect(key.allowedModels).toEqual(["claude-3-5-sonnet-*", "gpt-4o"]);
+
+    const fetched = await getApiKeyById(key.id);
+    expect(fetched.rpm).toBe(10);
+    expect(fetched.allowedModels).toEqual(["claude-3-5-sonnet-*", "gpt-4o"]);
+  });
+
+  it("enforces expiration date on validateApiKey and checkApiKeyLimits", async () => {
+    const pastDate = new Date(Date.now() - 3600000).toISOString();
+    const expiredKey = await createApiKey("Expired", "machine-123", {
+      expiresAt: pastDate,
+    });
+
+    const valid = await validateApiKey(expiredKey.key);
+    expect(valid).toBeNull();
+
+    const check = await checkApiKeyLimits(expiredKey, 0);
+    expect(check.allowed).toBe(false);
+    expect(check.reason).toContain("expired");
+  });
+
+  it("enforces allowedModels matching with exact and wildcard support", () => {
+    const keyInfo = {
+      allowedModels: ["claude-3-5-sonnet-*", "gpt-4o", "antigravity/gemini-2.5*"],
+    };
+
+    expect(isModelAllowed(keyInfo, "claude-3-5-sonnet-20241022")).toBe(true);
+    expect(isModelAllowed(keyInfo, "claude-3-5-sonnet-latest")).toBe(true);
+    expect(isModelAllowed(keyInfo, "gpt-4o")).toBe(true);
+    expect(isModelAllowed(keyInfo, "antigravity/gemini-2.5-flash")).toBe(true);
+
+    expect(isModelAllowed(keyInfo, "claude-3-opus-20240229")).toBe(false);
+    expect(isModelAllowed(keyInfo, "gpt-4o-mini")).toBe(false);
+    expect(isModelAllowed(keyInfo, "deepseek-r1")).toBe(false);
+  });
+
+  it("atomically enforces RPM and RPH rate limits", async () => {
+    const key = await createApiKey("Rate Limited Key", "machine-123", {
+      rpm: 2,
+    });
+
+    // 1st request admission & reservation
+    const check1 = await checkApiKeyLimits(key, 100, true);
+    expect(check1.allowed).toBe(true);
+
+    // 2nd request admission & reservation
+    const check2 = await checkApiKeyLimits(key, 100, true);
+    expect(check2.allowed).toBe(true);
+
+    // 3rd request should be blocked
+    const check3 = await checkApiKeyLimits(key, 100, true);
+    expect(check3.allowed).toBe(false);
+    expect(check3.reason).toContain("requests per minute");
+    expect(check3.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  it("atomically tracks token usage across rolling windows and snapshots", async () => {
+    const key = await createApiKey("Token Limited Key", "machine-123", {
+      maxTokensDaily: 1000,
+      tokens5h: 500,
+    });
+
+    // Record usage
+    await recordApiKeyUsage(key, 300);
+
+    let snapshot = await getApiKeyUsageSnapshot(key);
+    expect(snapshot.maxTokensDaily.used).toBe(300);
+    expect(snapshot.tokens5h.used).toBe(300);
+    expect(snapshot.rpm.used).toBe(1);
+
+    // Admission for 150 tokens should pass (300 + 150 <= 500)
+    const check1 = await checkApiKeyLimits(key, 150);
+    expect(check1.allowed).toBe(true);
+
+    // Admission for 250 tokens should fail 5h rolling limit (300 + 250 > 500)
+    const check2 = await checkApiKeyLimits(key, 250);
+    expect(check2.allowed).toBe(false);
+    expect(check2.reason).toContain("5-hour rolling token window");
+  });
+
+  it("deletes usage records cascading when key is deleted", async () => {
+    const key = await createApiKey("To Delete", "machine-123", { rpm: 5 });
+    await recordApiKeyUsage(key, 500);
+
+    const deleted = await deleteApiKey(key.id);
+    expect(deleted).toBe(true);
+
+    const buckets = db.all("SELECT * FROM apiKeyUsageBuckets WHERE keyId = ?", [key.id]);
+    expect(buckets.length).toBe(0);
+
+    const events = db.all("SELECT * FROM apiKeyTokenEvents WHERE keyId = ?", [key.id]);
+    expect(events.length).toBe(0);
+  });
+});

--- a/tests/unit/chat-pre-credential-retry-after.test.js
+++ b/tests/unit/chat-pre-credential-retry-after.test.js
@@ -71,12 +71,18 @@ vi.mock("@/lib/localDb", () => ({
   getProviderConnections: vi.fn(() => []),
   validateApiKey: vi.fn(),
   getProviderNodeById: vi.fn(),
+  checkApiKeyLimits: vi.fn().mockResolvedValue({ allowed: true }),
+  recordApiKeyUsage: vi.fn().mockResolvedValue(undefined),
+  getApiKeyUsageSnapshot: vi.fn().mockResolvedValue(null),
 }));
 vi.mock("../../src/lib/localDb.js", () => ({
   getSettings: mocks.getSettings,
   getProviderConnections: vi.fn(() => []),
   validateApiKey: vi.fn(),
   getProviderNodeById: vi.fn(),
+  checkApiKeyLimits: vi.fn().mockResolvedValue({ allowed: true }),
+  recordApiKeyUsage: vi.fn().mockResolvedValue(undefined),
+  getApiKeyUsageSnapshot: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock("@/sse/services/model.js", () => ({

--- a/tests/unit/handler-acl-enforcement.test.js
+++ b/tests/unit/handler-acl-enforcement.test.js
@@ -90,12 +90,18 @@ vi.mock("@/lib/localDb", () => ({
   getProviderConnections: vi.fn(() => []),
   validateApiKey: vi.fn(),
   getProviderNodeById: vi.fn(),
+  checkApiKeyLimits: vi.fn().mockResolvedValue({ allowed: true }),
+  recordApiKeyUsage: vi.fn().mockResolvedValue(undefined),
+  getApiKeyUsageSnapshot: vi.fn().mockResolvedValue(null),
 }));
 vi.mock("../../src/lib/localDb.js", () => ({
   getSettings: mocks.getSettings,
   getProviderConnections: vi.fn(() => []),
   validateApiKey: vi.fn(),
   getProviderNodeById: vi.fn(),
+  checkApiKeyLimits: vi.fn().mockResolvedValue({ allowed: true }),
+  recordApiKeyUsage: vi.fn().mockResolvedValue(undefined),
+  getApiKeyUsageSnapshot: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock("@/sse/services/model.js", () => ({ getModelInfo: mocks.getModelInfo, getComboModels: mocks.getComboModels }));


### PR DESCRIPTION
Focused revision (split from PR #77 per maintainer feedback).

Scope:
- schema/migration (005-add-api-key-limits)
- repository/API validation (apiKeyUsageRepo, apiKeysRepo)
- enforcement across modalities (chat handlers, /v1/models)
- concurrency semantics + persistence
- tests

This is the persistence-backed API-key limits feature only — no proxy rotation, no token-saver removal, no unrelated UI.