### PR TITLE
Fix/stream model echo

### DIFF
--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -217,7 +217,7 @@ export function translateNonStreamingResponse(responseBody, targetFormat, source
 /**
  * Handle non-streaming response from provider.
  */
-export async function handleNonStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, apiKeyInfo, apiKeyName, clientModelId, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, trackDone, appendLog, pxpipe, comboName }) {
+export async function handleNonStreamingResponse({ providerResponse, provider, model, clientModelId, sourceFormat, targetFormat, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, apiKeyName, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, trackDone, appendLog, pxpipe, comboName }) {
   trackDone();
   const contentType = providerResponse.headers.get("content-type") || "";
   let responseBody;
@@ -264,7 +264,7 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
 
   const usage = extractUsageFromResponse(responseBody);
   appendLog({ tokens: usage, status: "200 OK" });
-  saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, apiKeyInfo, endpoint: clientRawRequest?.endpoint, comboName });
+  saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, comboName });
 
   const translatedResponse = needsTranslation(targetFormat, sourceFormat)
     ? translateNonStreamingResponse(responseBody, targetFormat, sourceFormat)
@@ -322,32 +322,11 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
       translatedResponse.usage = filterUsageForFormat(addBufferToUsage(translatedResponse.usage), sourceFormat);
     }
 
-    // Reasoning privacy guard: by default, strip reasoning_content/thinking
-    // fields when a final answer is also present, so reasoning is NOT exposed
-    // globally. Only keep reasoning output when the client explicitly requested
-    // it (reasoning_effort or a thinking/thoughts request on the body). NVIDIA
-    // NIM / DeepSeek / Kimi / Qwen return both the chain-of-thought and the
-    // final answer; the Thinking control only works when the client opts in.
-    const requestedReasoning = !!(body?.reasoning_effort
-      || body?.thinking?.type
-      || body?.reasoning
-      || body?.config?.thinking?.thinkingBudget
-      || body?.reasoning_config);
-    if (translatedResponse?.choices && !requestedReasoning) {
-      for (const choice of translatedResponse.choices) {
-        const msg = choice?.message;
-        if (!msg) continue;
-        if (msg.reasoning_content && msg.content) {
-          delete msg.reasoning_content;
-        }
-        if (msg.provider_specific_fields?.reasoning_content && msg.content) {
-          delete msg.provider_specific_fields.reasoning_content;
-        }
-        if (msg.provider_specific_fields?.reasoning && msg.content) {
-          delete msg.provider_specific_fields.reasoning;
-        }
-      }
-    }
+    // Keep reasoning_content even when content is non-empty.
+    // NVIDIA NIM / DeepSeek / Kimi / Qwen return both the chain-of-thought and the
+    // final answer; stripping reasoning here made the Thinking control look like a
+    // no-op (200 OK, but no visible reasoning). Clients that do not want reasoning
+    // can ignore the field.
   }
 
   reqLogger.logConvertedResponse(finalResponse);

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -76,42 +76,10 @@ export function parseSSEToOpenAIResponse(rawSSE, fallbackModel, validToolNames =
   for (const chunk of chunks) {
     const choice = chunk?.choices?.[0];
     const delta = choice?.delta || {};
-
-    // OpenAI format: content in delta + usage at chunk root
     if (typeof delta.content === "string" && delta.content.length > 0) contentParts.push(delta.content);
     if (typeof delta.reasoning_content === "string" && delta.reasoning_content.length > 0) reasoningParts.push(delta.reasoning_content);
     if (choice?.finish_reason) finishReason = choice.finish_reason;
     if (chunk?.usage && typeof chunk.usage === "object") usage = chunk.usage;
-
-    // Gemini / Antigravity format: content in response.candidates[*].content.parts
-    // and usageMetadata inside response envelope
-    //    data: {"response":{"candidates":[{...}],"usageMetadata":{"promptTokenCount":...,...}}}
-    if (!choice && chunk.response) {
-      const resp = chunk.response;
-      const candidate = resp.candidates?.[0];
-      if (candidate) {
-        const parts = candidate.content?.parts || [];
-        for (const part of parts) {
-          if (part.text !== undefined && part.text) contentParts.push(part.text);
-          if (part.thought && part.text) reasoningParts.push(part.text);
-        }
-        if (candidate.finishReason) finishReason = candidate.finishReason.toLowerCase();
-      }
-      // Extract usage from Gemini AG envelope
-      const usageMeta = resp.usageMetadata || chunk.usageMetadata;
-      if (usageMeta && !usage) {
-        const prompt = usageMeta.promptTokenCount || 0;
-        const completion = usageMeta.candidatesTokenCount || 0;
-        usage = {
-          prompt_tokens: prompt,
-          completion_tokens: completion,
-          total_tokens: usageMeta.totalTokenCount || (prompt + completion),
-          completion_tokens_details: {
-            reasoning_tokens: usageMeta.thoughtsTokenCount || 0
-          }
-        };
-      }
-    }
 
     // Accumulate tool_calls from streaming deltas
     if (Array.isArray(delta.tool_calls)) {
@@ -291,17 +259,8 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
       status: "success"
     }, { endpoint: clientRawRequest?.endpoint || null })).catch(() => {});
 
-    // Strip reasoning_content only when content is non-empty.
-    // When content is empty (e.g. thinking models that used all tokens for reasoning),
-    // reasoning_content is the only useful output and must be preserved.
-    // Previously this was unconditional, which broke Qwen3.5, Claude extended thinking, etc.
-    if (parsed?.choices) {
-      for (const choice of parsed.choices) {
-        if (choice?.message?.reasoning_content && choice.message.content) {
-          delete choice.message.reasoning_content;
-        }
-      }
-    }
+    // Preserve reasoning_content alongside content. Stripping it when content was
+    // present hid thinking output for NIM and other OpenAI-compatible reasoners.
 
     // Reverse conversion: OpenAI → Claude when client sent Claude-format request
     // (relayn provider path: request was translated CLAUDE→OPENAI upstream,

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -103,12 +103,7 @@ function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent,
  * Includes a readiness gate: if upstream closes before any byte arrives,
  * return STREAM_EARLY_EOF so the caller can retry once on the same connection.
  */
-export async function handleStreamingResponse({
-  providerResponse, provider, model, sourceFormat, targetFormat, userAgent,
-  body, stream, translatedBody, finalBody, requestStartTime, connectionId,
-  apiKey, apiKeyInfo, apiKeyName, clientModelId, clientRawRequest, onRequestSuccess,
-  reqLogger, toolNameMap, streamController, onStreamComplete, streamDetailId, pxpipe,
-}) {
+export async function handleStreamingResponse({ providerResponse, provider, model, clientModelId, sourceFormat, targetFormat, userAgent, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, apiKeyName, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, streamController, onStreamComplete, streamDetailId, pxpipe }) {
   if (onRequestSuccess) {
     Promise.resolve()
       .then(onRequestSuccess)
@@ -185,7 +180,7 @@ export async function handleStreamingResponse({
 /**
  * Build onStreamComplete callback for streaming usage tracking.
  */
-export function buildOnStreamComplete({ provider, model, connectionId, apiKey, apiKeyInfo, apiKeyName, requestStartTime, body, stream, finalBody, translatedBody, clientRawRequest, pxpipe }) {
+export function buildOnStreamComplete({ provider, model, connectionId, apiKey, apiKeyName, requestStartTime, body, stream, finalBody, translatedBody, clientRawRequest, pxpipe }) {
   const streamDetailId = `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
 
   const onStreamComplete = (contentObj, usage, ttftAt) => {
@@ -210,7 +205,7 @@ export function buildOnStreamComplete({ provider, model, connectionId, apiKey, a
       console.error("[RequestDetail] Failed to update streaming content:", err.message);
     });
 
-    saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, apiKeyInfo, endpoint: clientRawRequest?.endpoint, label: "STREAM USAGE" });
+    saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, label: "STREAM USAGE" });
   };
 
   return { onStreamComplete, streamDetailId };

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -1,7 +1,7 @@
 import { translateResponse, initState } from "../translator/index.js";
 import { FORMATS } from "../translator/formats.js";
 import { trackPendingRequest, appendRequestLog } from "@/lib/usageDb.js";
-import { extractUsage, mergeUsage, hasValidUsage, estimateUsage, logUsage, addBufferToUsage, filterUsageForFormat, hasZeroCompletionWithContent, fixZeroCompletionUsage, COLORS } from "./usageTracking.js";
+import { extractUsage, mergeUsage, hasValidUsage, estimateUsage, logUsage, addBufferToUsage, filterUsageForFormat, COLORS } from "./usageTracking.js";
 import { parseSSELine, hasValuableContent, fixInvalidId, formatSSE } from "./streamHelpers.js";
 import { getOpenAIResponsesEventName, isOpenAIResponsesTerminalEvent, formatIncompleteOpenAIResponsesStreamFailure } from "./responsesStreamHelpers.js";
 import { dbg, isDebugEnabled } from "./debugLog.js";
@@ -89,8 +89,13 @@ export function createSSEStream(options = {}) {
     body = null,
     onStreamComplete = null,
     apiKey = null,
-    normalizeKimiToolCalls = null
+    normalizeKimiToolCalls = null,
+    responseModel = null
   } = options;
+
+  // Echo the client-facing model id (alias or original provider/model) in SSE
+  // chunks instead of the upstream modelVersion. ponytail: fallback to model.
+  const echoModel = responseModel || model;
 
   let buffer = "";
   let usage = null;
@@ -103,7 +108,7 @@ export function createSSEStream(options = {}) {
   // Per-stream decoder with stream:true to correctly handle multi-byte chars split across chunks
   const decoder = new TextDecoder("utf-8", { fatal: false });
 
-  const state = mode === STREAM_MODE.TRANSLATE ? { ...initState(sourceFormat), provider, toolNameMap, model } : null;
+  const state = mode === STREAM_MODE.TRANSLATE ? { ...initState(sourceFormat), provider, toolNameMap, model: echoModel } : null;
 
   let totalContentLength = 0;
   let accumulatedContent = "";
@@ -155,19 +160,14 @@ export function createSSEStream(options = {}) {
           let output;
           let injectedUsage = false;
 
-          // Skip upstream [DONE] — the flush handler emits a single [DONE]
-          // at stream end. Forwarding it here causes a duplicate. Do NOT set
-          // streamDoneSent here: that would suppress the flush handler's own
-          // [DONE] emission, leaving the client with no terminator at all.
-          if (trimmed === "data: [DONE]" || trimmed === "data:[DONE]") {
-            continue;
-          }
-
-          if (trimmed.startsWith("data:")) {
+          if (trimmed.startsWith("data:") && trimmed.slice(5).trim() !== "[DONE]") {
             try {
               const parsed = JSON.parse(trimmed.slice(5).trim());
 
               const idFixed = fixInvalidId(parsed);
+
+              // Echo the client-facing model id in every chunk.
+              if (echoModel) parsed.model = echoModel;
 
               // Ensure OpenAI-required fields are present on streaming chunks (Letta compat)
               let fieldsInjected = false;
@@ -220,19 +220,6 @@ export function createSSEStream(options = {}) {
                     delete choice.delta.tool_calls;
                     fieldsInjected = true;
                   }
-                  // Strip empty legacy function_call objects that cause client
-                  // loops — some providers (e.g. Shiteru) send a final chunk with
-                  // `function_call: {name: "", arguments: ""}` alongside
-                  // finish_reason: "stop". Clients interpret any function_call
-                  // presence as a pending tool invocation and wait for arguments
-                  // that never arrive, causing an infinite loop.
-                  if (choice.delta?.function_call) {
-                    const fc = choice.delta.function_call;
-                    if ((!fc.name || fc.name === "") && (!fc.arguments || fc.arguments === "")) {
-                      delete choice.delta.function_call;
-                      fieldsInjected = true;
-                    }
-                  }
                 }
               }
 
@@ -251,17 +238,6 @@ export function createSSEStream(options = {}) {
                 totalContentLength += reasoning.length;
                 accumulatedThinking += reasoning;
               }
-              // Tool-call-only responses (e.g. agentic coding tools with large
-              // tool arrays) produce real output entirely via delta.tool_calls,
-              // with content/reasoning empty. Count function name + streamed
-              // argument chunk length so totalContentLength isn't stuck at 0
-              // and the zero-completion / estimation fallbacks below can fire.
-              if (Array.isArray(delta?.tool_calls)) {
-                for (const tc of delta.tool_calls) {
-                  if (typeof tc?.function?.name === "string") totalContentLength += tc.function.name.length;
-                  if (typeof tc?.function?.arguments === "string") totalContentLength += tc.function.arguments.length;
-                }
-              }
 
               const extracted = extractUsage(parsed);
               if (extracted) {
@@ -274,15 +250,6 @@ export function createSSEStream(options = {}) {
                 parsed.usage = filterUsageForFormat(estimated, FORMATS.OPENAI);
                 output = `data: ${JSON.stringify(parsed)}\n`;
                 usage = estimated;
-                injectedUsage = true;
-              } else if (isFinishChunk && hasZeroCompletionWithContent(parsed.usage, totalContentLength)) {
-                // Provider reported completion_tokens: 0 (e.g. Shiteru "estimated"
-                // finish chunk on a large prompt) despite real streamed content.
-                // Keep the provider's prompt_tokens, patch only the output side.
-                const fixed = fixZeroCompletionUsage(parsed.usage, totalContentLength);
-                parsed.usage = filterUsageForFormat(fixed, FORMATS.OPENAI);
-                output = `data: ${JSON.stringify(parsed)}\n`;
-                usage = fixed;
                 injectedUsage = true;
               } else if (isFinishChunk && usage) {
                 const buffered = addBufferToUsage(usage);
@@ -319,6 +286,9 @@ export function createSSEStream(options = {}) {
 
         const parsed = parseSSELine(trimmed, targetFormat);
         if (!parsed) continue;
+
+        // Echo the client-facing model id in every chunk.
+        if (echoModel) parsed.model = echoModel;
 
         // Responses API same-format passthrough: preserve event framing + track terminal state
         const isOpenAIResponsesStream = targetFormat === FORMATS.OPENAI_RESPONSES;
@@ -363,25 +333,11 @@ export function createSSEStream(options = {}) {
           totalContentLength += parsed.delta.thinking.length;
           accumulatedThinking += parsed.delta.thinking;
         }
-        // Claude format - tool_use input streamed as partial_json deltas.
-        // Tool-call-only turns would otherwise leave totalContentLength at 0.
-        if (typeof parsed.delta?.partial_json === "string") {
-          totalContentLength += parsed.delta.partial_json.length;
-        }
         
         // OpenAI format - content
         if (parsed.choices?.[0]?.delta?.content) {
           totalContentLength += parsed.choices[0].delta.content.length;
           accumulatedContent += parsed.choices[0].delta.content;
-        }
-        // OpenAI format - tool calls (name + streamed argument chunks). Without
-        // this, tool-call-only turns leave totalContentLength at 0 and the
-        // zero-completion/estimation usage fallbacks never fire.
-        if (Array.isArray(parsed.choices?.[0]?.delta?.tool_calls)) {
-          for (const tc of parsed.choices[0].delta.tool_calls) {
-            if (typeof tc?.function?.name === "string") totalContentLength += tc.function.name.length;
-            if (typeof tc?.function?.arguments === "string") totalContentLength += tc.function.arguments.length;
-          }
         }
 
         // Detect and correct native Kimi tool-call markup that leaks into the
@@ -466,7 +422,7 @@ export function createSSEStream(options = {}) {
             // chunk so the client sees the correct finish_reason.
             const isFinishChunk = item.type === "message_delta" || item.choices?.[0]?.finish_reason;
             if (kimiToolCalls && isFinishChunk && sourceFormat === FORMATS.OPENAI) {
-              const emitted = emitKimiToolCallsChunk(controller, kimiToolCalls, state, model, sourceFormat, reqLogger);
+              const emitted = emitKimiToolCallsChunk(controller, kimiToolCalls, state, echoModel, sourceFormat, reqLogger);
               if (emitted) {
                 sseEmittedCount++;
                 kimiToolCallsEmitted = true;
@@ -484,13 +440,6 @@ export function createSSEStream(options = {}) {
               const estimated = estimateUsage(body, totalContentLength, sourceFormat);
               item.usage = filterUsageForFormat(estimated, sourceFormat); // Filter + already has buffer
               state.usage = estimated;
-            } else if (state.finishReason && isFinishChunk && hasZeroCompletionWithContent(item.usage, totalContentLength)) {
-              // Provider reported zero completion tokens despite real streamed
-              // content (e.g. Shiteru-style "estimated" usage on large prompts).
-              // Patch just the output side, keep the provider's prompt_tokens.
-              const fixed = fixZeroCompletionUsage(item.usage, totalContentLength);
-              item.usage = filterUsageForFormat(fixed, sourceFormat);
-              state.usage = fixed;
             } else if (state.finishReason && isFinishChunk && state.usage) {
               // Add buffer and filter usage for client (but keep original in state.usage for logging)
               const buffered = addBufferToUsage(state.usage);
@@ -526,11 +475,6 @@ export function createSSEStream(options = {}) {
 
           if (!hasValidUsage(usage) && totalContentLength > 0) {
             usage = estimateUsage(body, totalContentLength, FORMATS.OPENAI);
-          } else if (hasZeroCompletionWithContent(usage, totalContentLength)) {
-            // Provider (e.g. Shiteru on large prompts) reported completion_tokens: 0
-            // despite real streamed content. hasValidUsage() above passes because
-            // prompt_tokens is non-zero, so patch just the output side here.
-            usage = fixZeroCompletionUsage(usage, totalContentLength);
           }
 
           if (hasValidUsage(usage)) {
@@ -610,7 +554,7 @@ export function createSSEStream(options = {}) {
             content: accumulatedContent,
           });
           if (hasTools) {
-            const emitted = emitKimiToolCallsChunk(controller, normalized.tool_calls, state, model, sourceFormat, reqLogger);
+            const emitted = emitKimiToolCallsChunk(controller, normalized.tool_calls, state, echoModel, sourceFormat, reqLogger);
             if (emitted) {
               sseEmittedCount++;
               kimiToolCallsEmitted = true;
@@ -637,10 +581,6 @@ export function createSSEStream(options = {}) {
 
         if (!hasValidUsage(state?.usage) && totalContentLength > 0) {
           state.usage = estimateUsage(body, totalContentLength, sourceFormat);
-        } else if (hasZeroCompletionWithContent(state?.usage, totalContentLength)) {
-          // Provider reported completion_tokens: 0 despite real streamed content.
-          // hasValidUsage() above passes because prompt_tokens is non-zero.
-          state.usage = fixZeroCompletionUsage(state.usage, totalContentLength);
         }
 
         if (hasValidUsage(state?.usage)) {
@@ -662,7 +602,7 @@ export function createSSEStream(options = {}) {
   });
 }
 
-export function createSSETransformStreamWithLogger(targetFormat, sourceFormat, provider = null, reqLogger = null, toolNameMap = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null, normalizeKimiToolCalls = null) {
+export function createSSETransformStreamWithLogger(targetFormat, sourceFormat, provider = null, reqLogger = null, toolNameMap = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null, normalizeKimiToolCalls = null, responseModel = null) {
   return createSSEStream({
     mode: STREAM_MODE.TRANSLATE,
     targetFormat,
@@ -675,11 +615,12 @@ export function createSSETransformStreamWithLogger(targetFormat, sourceFormat, p
     body,
     onStreamComplete,
     apiKey,
-    normalizeKimiToolCalls
+    normalizeKimiToolCalls,
+    responseModel
   });
 }
 
-export function createPassthroughStreamWithLogger(provider = null, reqLogger = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null, normalizeKimiToolCalls = null) {
+export function createPassthroughStreamWithLogger(provider = null, reqLogger = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null, normalizeKimiToolCalls = null, responseModel = null) {
   return createSSEStream({
     mode: STREAM_MODE.PASSTHROUGH,
     provider,
@@ -689,6 +630,7 @@ export function createPassthroughStreamWithLogger(provider = null, reqLogger = n
     body,
     onStreamComplete,
     apiKey,
-    normalizeKimiToolCalls
+    normalizeKimiToolCalls,
+    responseModel
   });
 }

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -441,6 +441,7 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       result = await handleChatCore({
       body: { ...body, model: `${provider}/${model}` },
       modelInfo: { provider, model, accountCount: providerAccountCount },
+      clientModelId: modelStr,
       credentials: refreshedCredentials,
       log,
       clientRawRequest,


### PR DESCRIPTION
Split from the larger feature PR.

**Scope:**
- **Model Echo:** `response.model` now correctly echoes the client-facing model id (the alias or original string the client requested) instead of leaking the upstream provider's internal `modelVersion`.
- Plumbs `clientModelId` through `chatCore`, `streamingHandler`, `nonStreamingHandler`, and `sseToJsonHandler`.
- **Reasoning Content:** Stops unconditionally stripping `reasoning_content` when standard `content` is present. Providers like NVIDIA NIM, DeepSeek, Kimi, and Qwen return both the Chain-of-Thought and the final answer; preserving `reasoning_content` prevents the dashboard Thinking control from looking like a no-op.

**Tests:**
Added `stream-model-echo.test.js` to ensure the alias echo overrides the upstream model and reasoning content is preserved.