### PR TITLE
fix(antigravity): route to daily-cloudcode host first to avoid 429

### DIFF
--- a/open-sse/providers/registry/antigravity.js
+++ b/open-sse/providers/registry/antigravity.js
@@ -19,7 +19,12 @@ export default {
   category: "oauth",
   serviceKinds: ["llm", "image"],
   transport: {
-    baseUrls: [ANTIGRAVITY_IDE_BASE_URL],
+    // Gemini 3.6 Flash is only served from the daily Cloud Code host today.
+    // Keep production as fallback for older models if daily flakes.
+    baseUrls: [
+      "https://daily-cloudcode-pa.googleapis.com",
+      ANTIGRAVITY_IDE_BASE_URL,
+    ],
     format: "antigravity",
     headers: {
       "User-Agent": ANTIGRAVITY_IDE_USER_AGENT,


### PR DESCRIPTION
## Summary
- Prepend `https://daily-cloudcode-pa.googleapis.com` to Antigravity `baseUrls` (production host stays as fallback).
- Gemini 3.6 Flash is only served from the daily Cloud Code host today.

## Why
The production host (`cloudcode-pa.googleapis.com`) returns **HTTP 429 RESOURCE_EXHAUSTED** for the same OAuth accounts that work fine on `daily-cloudcode-pa.googleapis.com` — Google keeps a separate quota bucket per host. Requests routed to the exhausted bucket fail for every model.

Repro (same OAuth token, same account):
- `https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent` → **429**
- `https://daily-cloudcode-pa.googleapis.com/v1internal:streamGenerateContent` → **200**

## Test Plan
- [x] Verified 9Router (already on this ordering) returns 200 for `ag/gemini-3.6-flash-high`
- [x] Patching the same ordering into a 0.9.99 VansRouter bundle + clearing stale modelLock DB rows turned `ag/gemini-3.6-flash-high` / `ag/gemini-3.6-flash-medium` / `ag/gemini-3.6-flash-low` / `ag/gemini-3.1-pro-low` from 429 → 200 (live test)
- [ ] CI passes