### PR TITLE
feat(antigravity): add Gemini 3.7 Flash models & route daily host first

### DIFF
--- a/cli/src/cli/menus/providers.js
+++ b/cli/src/cli/menus/providers.js
@@ -53,6 +53,9 @@ const PROVIDER_MODELS = {
     { id: "glm-4.7" },
   ],
   ag: [
+    { id: "gemini-3.7-flash-high" },
+    { id: "gemini-3.7-flash-medium" },
+    { id: "gemini-3.7-flash-low" },
     { id: "gemini-3.6-flash-high" },
     { id: "gemini-3.6-flash-medium" },
     { id: "gemini-3.6-flash-low" },

--- a/open-sse/config/antigravityModelAliases.js
+++ b/open-sse/config/antigravityModelAliases.js
@@ -1,3 +1,11 @@
+const GEMINI_37_FLASH_BASE = Object.freeze({
+  contextLength: 1048576,
+  maxOutputTokens: 65536,
+  supportsReasoning: true,
+  supportsVision: true,
+  toolCalling: true,
+});
+
 const GEMINI_36_FLASH_BASE = Object.freeze({
   contextLength: 1048576,
   maxOutputTokens: 65536,
@@ -34,6 +42,9 @@ export const ANTIGRAVITY_PUBLIC_MODELS = Object.freeze([
     supportsVision: true,
     toolCalling: true,
   },
+  { id: "gemini-3.7-flash-high", name: "Gemini 3.7 Flash (High)", ...GEMINI_37_FLASH_BASE },
+  { id: "gemini-3.7-flash-medium", name: "Gemini 3.7 Flash (Medium)", ...GEMINI_37_FLASH_BASE },
+  { id: "gemini-3.7-flash-low", name: "Gemini 3.7 Flash (Low)", ...GEMINI_37_FLASH_BASE },
   { id: "gemini-3.6-flash-high", name: "Gemini 3.6 Flash (High)", ...GEMINI_36_FLASH_BASE },
   { id: "gemini-3.6-flash-medium", name: "Gemini 3.6 Flash (Medium)", ...GEMINI_36_FLASH_BASE },
   { id: "gemini-3.6-flash-low", name: "Gemini 3.6 Flash (Low)", ...GEMINI_36_FLASH_BASE },
@@ -154,6 +165,8 @@ export const ANTIGRAVITY_PUBLIC_MODELS = Object.freeze([
 ]);
 
 export const ANTIGRAVITY_MODEL_ALIASES = Object.freeze({
+  "gemini-3.7-flash": "gemini-3.7-flash-medium",
+  "gemini-3.7-flash-preview": "gemini-3.7-flash-high",
   "gemini-3.6-flash": "gemini-3.6-flash-medium",
   "gemini-3.6-flash-preview": "gemini-3.6-flash-high",
   "gemini-3.5-flash-low": "gemini-3.5-flash-extra-low",

--- a/open-sse/providers/registry/antigravity.js
+++ b/open-sse/providers/registry/antigravity.js
@@ -19,7 +19,12 @@ export default {
   category: "oauth",
   serviceKinds: ["llm", "image"],
   transport: {
-    baseUrls: [ANTIGRAVITY_IDE_BASE_URL],
+    // Gemini 3.6 Flash is only served from the daily Cloud Code host today.
+    // Keep production as fallback for older models if daily flakes.
+    baseUrls: [
+      "https://daily-cloudcode-pa.googleapis.com",
+      ANTIGRAVITY_IDE_BASE_URL,
+    ],
     format: "antigravity",
     headers: {
       "User-Agent": ANTIGRAVITY_IDE_USER_AGENT,

--- a/open-sse/providers/registry/antigravity.js
+++ b/open-sse/providers/registry/antigravity.js
@@ -49,6 +49,9 @@ export default {
     clientSecret: "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",
   },
   models: [
+    { id: "gemini-3.7-flash-high", name: "Gemini 3.7 Flash (High)" },
+    { id: "gemini-3.7-flash-medium", name: "Gemini 3.7 Flash (Medium)" },
+    { id: "gemini-3.7-flash-low", name: "Gemini 3.7 Flash (Low)" },
     { id: "gemini-3.6-flash-high", name: "Gemini 3.6 Flash (High)" },
     { id: "gemini-3.6-flash-medium", name: "Gemini 3.6 Flash (Medium)" },
     { id: "gemini-3.6-flash-low", name: "Gemini 3.6 Flash (Low)" },

--- a/open-sse/providers/registry/gemini-cli.js
+++ b/open-sse/providers/registry/gemini-cli.js
@@ -31,6 +31,7 @@ export default {
     clientSecret: "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",
   },
   models: [
+    { id: "gemini-3.7-flash-preview", name: "Gemini 3.7 Flash Preview" },
     { id: "gemini-3.1-pro-preview", name: "Gemini 3.1 Pro Preview" },
     { id: "gemini-3-pro-preview", name: "Gemini 3 Pro Preview" },
     { id: "gemini-3-flash-preview", name: "Gemini 3 Flash Preview" },

--- a/open-sse/providers/registry/gemini.js
+++ b/open-sse/providers/registry/gemini.js
@@ -36,6 +36,7 @@ export default {
     },
   },
   models: [
+    { id: "gemini-3.7-flash-preview", name: "Gemini 3.7 Flash Preview" },
     { id: "gemini-3.1-pro-preview", name: "Gemini 3.1 Pro Preview" },
     { id: "gemini-3.1-flash-lite-preview", name: "Gemini 3.1 Flash Lite Preview" },
     { id: "gemini-3-flash-preview", name: "Gemini 3 Flash Preview" },

--- a/src/shared/constants/cliTools.js
+++ b/src/shared/constants/cliTools.js
@@ -8,8 +8,11 @@ export const MITM_TOOLS = {
     description: "Google Antigravity IDE with MITM",
     configType: "mitm",
     mitmDomain: "daily-cloudcode-pa.googleapis.com",
-    modelAliases: ["gemini-3.6-flash-high", "gemini-3.6-flash-medium", "gemini-3.6-flash-low", "gemini-3.5-flash-low", "gemini-3-flash-agent", "gemini-3.5-flash-extra-low", "gemini-3.1-pro-low", "gemini-pro-agent", "claude-sonnet-4-6", "claude-opus-4-6-thinking", "gpt-oss-120b-medium", "gemini-3-flash"],
+    modelAliases: ["gemini-3.7-flash-high", "gemini-3.7-flash-medium", "gemini-3.7-flash-low", "gemini-3.6-flash-high", "gemini-3.6-flash-medium", "gemini-3.6-flash-low", "gemini-3.5-flash-low", "gemini-3-flash-agent", "gemini-3.5-flash-extra-low", "gemini-3.1-pro-low", "gemini-pro-agent", "claude-sonnet-4-6", "claude-opus-4-6-thinking", "gpt-oss-120b-medium", "gemini-3-flash"],
     defaultModels: [
+      { id: "gemini-3.7-flash-high", name: "Gemini 3.7 Flash (High)", alias: "gemini-3.7-flash-high" },
+      { id: "gemini-3.7-flash-medium", name: "Gemini 3.7 Flash (Medium)", alias: "gemini-3.7-flash-medium" },
+      { id: "gemini-3.7-flash-low", name: "Gemini 3.7 Flash (Low)", alias: "gemini-3.7-flash-low" },
       { id: "gemini-3.6-flash-high", name: "Gemini 3.6 Flash (High)", alias: "gemini-3.6-flash-high" },
       { id: "gemini-3.6-flash-medium", name: "Gemini 3.6 Flash (Medium)", alias: "gemini-3.6-flash-medium" },
       { id: "gemini-3.6-flash-low", name: "Gemini 3.6 Flash (Low)", alias: "gemini-3.6-flash-low" },


### PR DESCRIPTION
Combines PR #99 (daily-cloudcode host routing to avoid 429) and PR #101 (Gemini 3.7 Flash models/aliases).