### PR TITLE
fix(kiro): 400 REQUEST_BODY_INVALID + non-us-east-1 region routing

### DIFF
--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -186,7 +186,14 @@ export class KiroExecutor extends BaseExecutor {
   }
 
   /**
-   * Auth-aware endpoint ordering.
+   * Region- and auth-aware endpoint ordering.
+   *
+   * Region first: the registry baseUrls are hardcoded us-east-1. An IAM Identity
+   * Center account homed elsewhere (e.g. eu-central-1) only resolves through the
+   * regional Amazon Q host, so it gets that single endpoint. Rewriting the host
+   * per-region is not an option — `codewhisperer.<region>.amazonaws.com` does not
+   * exist outside us-east-1. us-east-1 (and an unset region) keeps the registry
+   * list untouched, so existing accounts are unaffected.
    *
    * API-key Kiro connections store a raw CodeWhisperer credential (validated
    * against codewhisperer.us-east-1.amazonaws.com via ListAvailableProfiles).
@@ -197,28 +204,22 @@ export class KiroExecutor extends BaseExecutor {
    * CodeWhisperer hosts FIRST, mirroring the Kiro-Go reference fork which never
    * routes api-key traffic through kiro.dev. External IdP enterprise tokens also
    * use the CodeWhisperer surface, with the `TokenType: EXTERNAL_IDP` header.
+   * IAM Identity Center (idc) tokens are AWS SSO access tokens from the same
+   * family; the kiro.dev gateway rejects them with 403 "bearer token invalid".
    * Other OAuth methods keep the default order (kiro.dev first) since their
    * tokens are what that gateway accepts.
    */
   getOrderedBaseUrls(credentials) {
+    const region = (credentials?.providerSpecificData?.region || "us-east-1").trim();
+    if (region && region !== "us-east-1") {
+      return [`https://q.${region}.amazonaws.com/generateAssistantResponse`];
+    }
     const baseUrls = this.getBaseUrls();
     const authMethod = credentials?.providerSpecificData?.authMethod;
-    // IAM Identity Center (idc) tokens are AWS SSO access tokens — the same
-    // family as external_idp/api_key. The kiro.dev gateway rejects them with
-    // 403 "bearer token invalid", so they must hit the CodeWhisperer
-    // *.amazonaws.com surface, and in the region the token was minted in
-    // (the baseUrls are hardcoded us-east-1).
     const isCodeWhispererSurface =
       authMethod === "api_key" || authMethod === "external_idp" || authMethod === "idc";
     if (!isCodeWhispererSurface) return baseUrls;
-
-    const region = (credentials?.providerSpecificData?.region || "us-east-1").trim();
-    const regionalize = (u) =>
-      region && region !== "us-east-1" && u.includes("amazonaws.com")
-        ? u.replace(/([a-z]+)\.[a-z0-9-]+\.amazonaws\.com/, `$1.${region}.amazonaws.com`)
-        : u;
-
-    const amazon = baseUrls.filter((u) => u.includes("amazonaws.com")).map(regionalize);
+    const amazon = baseUrls.filter((u) => u.includes("amazonaws.com"));
     const others = baseUrls.filter((u) => !u.includes("amazonaws.com"));
     return amazon.length > 0 ? [...amazon, ...others] : baseUrls;
   }

--- a/open-sse/translator/request/claude-to-kiro.js
+++ b/open-sse/translator/request/claude-to-kiro.js
@@ -448,7 +448,9 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
   };
 
   if (profileArn) payload.profileArn = profileArn;
-  if (systemPrompt) payload.systemPrompt = systemPrompt;
+  // No top-level `systemPrompt`: GenerateAssistantResponse answers any payload
+  // carrying it with 400 {"reason":"REQUEST_BODY_INVALID"}. The same text is
+  // already delivered through contentPrefix.
   if (additionalModelRequestFields) {
     payload.additionalModelRequestFields = additionalModelRequestFields;
   }

--- a/open-sse/translator/request/openai-to-kiro.js
+++ b/open-sse/translator/request/openai-to-kiro.js
@@ -483,9 +483,9 @@ export function openaiToKiroRequest(model, body, stream, credentials) {
 
   const timestamp = new Date().toISOString();
 
-  // Kiro CLI/KAS sends these as top-level systemPrompt. Keep a content fallback
-  // too because the CodeWhisperer surface does not always enforce top-level
-  // systemPrompt for direct calls.
+  // System directives ride inside the session-start user message content (see
+  // contentPrefix below) rather than a top-level field, because the
+  // CodeWhisperer GenerateAssistantResponse surface rejects the latter.
   const systemPromptParts = [];
   if (thinkingBudget !== null && !usesNativeGptEffort) {
     systemPromptParts.push(buildThinkingSystemPrefix(thinkingBudget));
@@ -555,7 +555,9 @@ export function openaiToKiroRequest(model, body, stream, credentials) {
   if (profileArn) {
     payload.profileArn = profileArn;
   }
-  if (systemPrompt) payload.systemPrompt = systemPrompt;
+  // No top-level `systemPrompt`: GenerateAssistantResponse answers any payload
+  // carrying it with 400 {"reason":"REQUEST_BODY_INVALID"}. The same text is
+  // already delivered through contentPrefix.
   if (additionalModelRequestFields) {
     payload.additionalModelRequestFields = additionalModelRequestFields;
   }

--- a/tests/unit/kiro-request-body-invalid.test.js
+++ b/tests/unit/kiro-request-body-invalid.test.js
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import { openaiToKiroRequest } from "../../open-sse/translator/request/openai-to-kiro.js";
+import { claudeToKiroRequest } from "../../open-sse/translator/request/claude-to-kiro.js";
+import { KiroExecutor } from "../../open-sse/executors/kiro.js";
+
+/**
+ * Two Kiro defects, both reproduced live against
+ * runtime.us-east-1.kiro.dev/generateAssistantResponse.
+ *
+ * 1. Top-level `systemPrompt`. CodeWhisperer answers ANY payload carrying that
+ *    field with 400 {"message":"Improperly formed request.",
+ *    "reason":"REQUEST_BODY_INVALID"} — verified by sending the byte-identical
+ *    payload with and without it (200 vs 400). The router sets it whenever the
+ *    turn carries system text: a client `system` message, the `-thinking` budget
+ *    prefix, or the `-agentic` prompt. So every real harness 400'd on its first
+ *    turn while a bare "hello" still worked, and the per-account 429/error
+ *    bookkeeping cooled the connection down after the retries.
+ *
+ *    Nothing is lost by dropping it: the same text already reaches the model
+ *    through `contentPrefix`, which applyKiroSessionReplay folds into the
+ *    session-start user message.
+ *
+ * 2. Region rewriting. The registry baseUrls are hardcoded us-east-1, and the
+ *    old code regionalized them by substituting the region into each
+ *    *.amazonaws.com host — producing `codewhisperer.<region>.amazonaws.com`,
+ *    which does not resolve outside us-east-1. An IAM Identity Center account
+ *    homed elsewhere must use the regional Amazon Q host instead.
+ */
+const CREDENTIALS = {
+  providerSpecificData: {
+    authMethod: "social",
+    profileArn: "arn:aws:codewhisperer:us-east-1:1:profile/TEST",
+  },
+};
+
+function openaiBody(overrides = {}) {
+  return {
+    messages: [
+      { role: "system", content: "You are a helpful assistant." },
+      { role: "user", content: "hi" },
+    ],
+    ...overrides,
+  };
+}
+
+describe("Kiro payload omits the top-level systemPrompt (REQUEST_BODY_INVALID)", () => {
+  it("openai -> kiro drops it while keeping the system text in the message content", () => {
+    const payload = openaiToKiroRequest(
+      "claude-opus-5-thinking-agentic",
+      openaiBody(),
+      true,
+      CREDENTIALS
+    );
+
+    expect(payload).not.toHaveProperty("systemPrompt");
+
+    // The directive still has to reach the model, otherwise thinking silently
+    // turns off — assert the delivery path rather than just the absence.
+    const content = payload.conversationState.currentMessage.userInputMessage.content;
+    expect(content).toContain("<thinking_mode>");
+    expect(content).toContain("[Context: Current time is");
+  });
+
+  it("claude -> kiro drops it too", () => {
+    const payload = claudeToKiroRequest(
+      "claude-opus-5-thinking-agentic",
+      {
+        system: "You are a helpful assistant.",
+        messages: [{ role: "user", content: "hi" }],
+      },
+      true,
+      CREDENTIALS
+    );
+
+    expect(payload).not.toHaveProperty("systemPrompt");
+    expect(
+      payload.conversationState.currentMessage.userInputMessage.content
+    ).toContain("<thinking_mode>");
+  });
+
+  it("stays absent for a plain turn that carries no system text at all", () => {
+    const payload = openaiToKiroRequest(
+      "claude-sonnet-4.5",
+      { messages: [{ role: "user", content: "hi" }] },
+      true,
+      CREDENTIALS
+    );
+    expect(payload).not.toHaveProperty("systemPrompt");
+  });
+
+  it("keeps the fields CodeWhisperer does accept", () => {
+    const payload = openaiToKiroRequest("claude-sonnet-4.5", openaiBody(), true, CREDENTIALS);
+
+    // agentContinuationId is what lets Kiro reuse an agent session across turns;
+    // dropping it makes every turn look like a fresh conversation and re-bills
+    // the whole history, so guard it here.
+    expect(payload.conversationState.agentContinuationId).toBeTruthy();
+    expect(payload.conversationState.chatTriggerType).toBe("MANUAL");
+    expect(payload.profileArn).toBe(CREDENTIALS.providerSpecificData.profileArn);
+  });
+});
+
+describe("KiroExecutor.getOrderedBaseUrls — non-us-east-1 uses the regional Amazon Q host", () => {
+  const executor = new KiroExecutor();
+
+  it("routes an eu-central-1 IdC account to q.<region> only", () => {
+    const urls = executor.getOrderedBaseUrls({
+      providerSpecificData: { authMethod: "idc", region: "eu-central-1" },
+    });
+
+    expect(urls).toEqual([
+      "https://q.eu-central-1.amazonaws.com/generateAssistantResponse",
+    ]);
+  });
+
+  it("never emits a codewhisperer.<region> host, which does not resolve", () => {
+    for (const region of ["eu-central-1", "eu-west-1", "us-west-2", "ap-northeast-1"]) {
+      const urls = executor.getOrderedBaseUrls({
+        providerSpecificData: { authMethod: "idc", region },
+      });
+      for (const url of urls) {
+        expect(url).not.toMatch(/codewhisperer\.(?!us-east-1)/);
+      }
+    }
+  });
+
+  it("applies regardless of auth method, since the region binds the endpoint", () => {
+    for (const authMethod of ["idc", "api_key", "external_idp", "social", undefined]) {
+      const urls = executor.getOrderedBaseUrls({
+        providerSpecificData: { authMethod, region: "eu-central-1" },
+      });
+      expect(urls).toEqual([
+        "https://q.eu-central-1.amazonaws.com/generateAssistantResponse",
+      ]);
+    }
+  });
+
+  it("leaves us-east-1, an unset region and blank whitespace on the registry list", () => {
+    const baseUrls = executor.getBaseUrls();
+    for (const region of ["us-east-1", undefined, "   "]) {
+      expect(
+        executor.getOrderedBaseUrls({
+          providerSpecificData: { authMethod: "social", region },
+        })
+      ).toEqual(baseUrls);
+    }
+  });
+
+  it("still puts the CodeWhisperer surface first for us-east-1 api-key auth", () => {
+    const urls = executor.getOrderedBaseUrls({
+      providerSpecificData: { authMethod: "api_key" },
+    });
+    expect(urls[0]).toMatch(/amazonaws\.com/);
+  });
+
+  it("trims a padded region before interpolating it into the host", () => {
+    const urls = executor.getOrderedBaseUrls({
+      providerSpecificData: { authMethod: "idc", region: "  eu-central-1  " },
+    });
+    expect(urls).toEqual([
+      "https://q.eu-central-1.amazonaws.com/generateAssistantResponse",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Two defects on the Kiro / CodeWhisperer path, both reproduced live against `runtime.us-east-1.kiro.dev/generateAssistantResponse`.

### 1. Top-level `systemPrompt` → `400 REQUEST_BODY_INVALID`

`GenerateAssistantResponse` rejects any payload carrying that field:

```
[400] {"message":"Improperly formed request.","reason":"REQUEST_BODY_INVALID"}
```

Confirmed by sending the byte-identical payload with and without the field — `200` vs `400` on both `claude-opus-5` and `claude-sonnet-4.5`.

Both Kiro translators set it whenever the turn carries system text: a client `system` message, the `-thinking` budget prefix, or the `-agentic` prompt. The practical effect is that a bare `"hello"` works while every real harness `400`s on its first turn, and the retries then cool the account down:

```
[AUTH] kiro | all 1 accounts locked for claude-opus-5-thinking-agentic | lastError=[400]: REQUEST_BODY_INVALID
```

Nothing is lost by removing it. The same text already reaches the model through `contentPrefix`, which `applyKiroSessionReplay` folds into the session-start user message — so `<thinking_mode>` still arrives. The tests assert that delivery path, not merely the field's absence.

### 2. Region rewriting produced a host that does not resolve

The registry `baseUrls` are hardcoded `us-east-1`, and `getOrderedBaseUrls` regionalized them by substituting the region into each `*.amazonaws.com` host, yielding `codewhisperer.<region>.amazonaws.com` — which has no DNS record outside `us-east-1`. An IAM Identity Center account homed elsewhere (e.g. `eu-central-1`) is additionally rejected by the `us-east-1` hosts with `403 "bearer token invalid"`.

A non-default region now resolves to the regional Amazon Q endpoint, `https://q.<region>.amazonaws.com/generateAssistantResponse` — the only host that both resolves and accepts a region-bound token.

The region check runs **before** the auth-method branch, because the region binds the endpoint regardless of how the token was minted. `us-east-1`, an unset region and blank whitespace keep the registry list and its 429 rotation untouched, so existing Builder ID / social accounts are unaffected.

## Changes

| File | Change |
| --- | --- |
| `open-sse/translator/request/openai-to-kiro.js` | stop setting top-level `payload.systemPrompt` |
| `open-sse/translator/request/claude-to-kiro.js` | same |
| `open-sse/executors/kiro.js` | `getOrderedBaseUrls`: non-`us-east-1` → regional Amazon Q host |
| `tests/unit/kiro-request-body-invalid.test.js` | new regression guard (10 tests) |

Deliberately left alone: `agentContinuationId`, `agentTaskType` / `agentMode`, and the `attachIntegrityGate` buffering contract covered by `kiro-terminal-integrity.test.js` — none of them cause the 400, and one test asserts `agentContinuationId` survives, since dropping it makes every turn look like a fresh conversation and re-bills the whole history.

## Testing

- `tests/unit/kiro-request-body-invalid.test.js` — 10 tests. Against the unfixed baseline **6 fail**; with the fix all pass.
- Full Kiro suite green: **127/127** across `kiro-request-body-invalid`, `kiro-idc-regional-url`, `kiro-thinking-strip`, `kiro-terminal-integrity`, `kiro-conversation-canonicalization`, `kiro-nonstream-error`, `kiro-profile-arn`, `kiro-model-slots`, `kiro-external-idp`, `kiro-oauth-adapter`.
- `npm run lint:undef` clean.
- Live-validated on a social-auth Kiro account through a locally built bundle: `kr/claude-opus-5` answers instead of `400`.

Cross-region routing was exercised through the unit tests only — I have no `eu-central-1` IdC account to verify against.
