### PR TITLE
fix(translator): support image and document input for Antigravity Claude models

### DIFF
--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -138,6 +138,22 @@ export const MODEL_CAPABILITIES = {
     contextWindow: 1000000,
     maxOutput: 128000,
   },
+  "claude-opus-4-6-thinking": {
+    vision: true,
+    reasoning: true,
+    search: true,
+    thinkingFormat: "claude-adaptive",
+    contextWindow: 1000000,
+    maxOutput: 128000,
+  },
+  "claude-sonnet-4-6-thinking": {
+    vision: true,
+    reasoning: true,
+    search: true,
+    thinkingFormat: "claude-adaptive",
+    contextWindow: 1000000,
+    maxOutput: 128000,
+  },
   "claude-opus-4.8": {
     vision: true,
     reasoning: true,
@@ -716,6 +732,15 @@ export const PATTERN_CAPABILITIES = [
     },
   },
   {
+    pattern: "*claude*opus-4-6*",
+    caps: {
+      vision: true,
+      reasoning: true,
+      search: true,
+      thinkingFormat: "claude-adaptive",
+    },
+  },
+  {
     pattern: "*claude*opus-4.7*",
     caps: {
       vision: true,
@@ -735,6 +760,15 @@ export const PATTERN_CAPABILITIES = [
   },
   {
     pattern: "*claude*sonnet-4.6*",
+    caps: {
+      vision: true,
+      reasoning: true,
+      search: true,
+      thinkingFormat: "claude-adaptive",
+    },
+  },
+  {
+    pattern: "*claude*sonnet-4-6*",
     caps: {
       vision: true,
       reasoning: true,

--- a/open-sse/translator/request/claude-to-openai.js
+++ b/open-sse/translator/request/claude-to-openai.js
@@ -178,6 +178,17 @@ function convertClaudeMessage(msg) {
           }
           break;
 
+        case CLAUDE_BLOCK.DOCUMENT:
+          if (block.source?.type === "base64") {
+            parts.push({
+              type: OPENAI_BLOCK.FILE,
+              file: {
+                file_data: encodeDataUri(block.source.media_type, block.source.data)
+              }
+            });
+          }
+          break;
+
         case CLAUDE_BLOCK.TOOL_USE:
           toolCalls.push({
             id: block.id,

--- a/open-sse/translator/request/openai-to-gemini.js
+++ b/open-sse/translator/request/openai-to-gemini.js
@@ -338,6 +338,31 @@ function wrapInCloudCodeEnvelopeForClaude(model, claudeRequest, credentials = nu
         for (const block of msg.content) {
           if (block.type === CLAUDE_BLOCK.TEXT) {
             parts.push({ text: block.text });
+          } else if (block.type === CLAUDE_BLOCK.IMAGE) {
+            if (block.source?.type === "base64" && block.source.data) {
+              parts.push({
+                inlineData: {
+                  mimeType: block.source.media_type,
+                  data: block.source.data
+                }
+              });
+            } else if (block.source?.type === "url" && block.source.url) {
+              parts.push({
+                fileData: {
+                  fileUri: block.source.url,
+                  mimeType: "image/*"
+                }
+              });
+            }
+          } else if (block.type === CLAUDE_BLOCK.DOCUMENT) {
+            if (block.source?.type === "base64" && block.source.data) {
+              parts.push({
+                inlineData: {
+                  mimeType: block.source.media_type,
+                  data: block.source.data
+                }
+              });
+            }
           } else if (block.type === CLAUDE_BLOCK.TOOL_USE) {
             parts.push({
               thoughtSignature: signature,

--- a/tests/translator/bugs-antigravity.test.js
+++ b/tests/translator/bugs-antigravity.test.js
@@ -263,4 +263,59 @@ describe("Antigravity executor", () => {
     expect(out.request.contents).toEqual([{ role: "user", parts: [{ text: "prompt" }] }]);
     expect(out.request.contents.every(c => c.parts.length > 0)).toBe(true);
   });
+
+  it("converts Claude image and document blocks to inlineData for Claude Antigravity models", () => {
+    const claudeReq = {
+      model: "claude-opus-4-6-thinking",
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "explain this image" },
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/png",
+                data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+              },
+            },
+            {
+              type: "document",
+              source: {
+                type: "base64",
+                media_type: "application/pdf",
+                data: "JVBERi0xLjEKMSAwIG9iajw8L1R5cGUvQ2F0YWxvZy9QYWdlcyAyIDAgUj4+ZW5kb2Jq",
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const out = translateRequest(
+      FORMATS.CLAUDE,
+      FORMATS.ANTIGRAVITY,
+      "claude-opus-4-6-thinking",
+      claudeReq,
+      true,
+      { projectId: "p", connectionId: "c" }
+    );
+
+    const parts = out.request.contents[0].parts;
+    expect(parts).toHaveLength(3);
+    expect(parts[0]).toEqual({ text: "explain this image" });
+    expect(parts[1]).toEqual({
+      inlineData: {
+        mimeType: "image/png",
+        data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+      },
+    });
+    expect(parts[2]).toEqual({
+      inlineData: {
+        mimeType: "application/pdf",
+        data: "JVBERi0xLjEKMSAwIG9iajw8L1R5cGUvQ2F0YWxvZy9QYWdlcyAyIDAgUj4+ZW5kb2Jq",
+      },
+    });
+  });
 });


### PR DESCRIPTION
### Summary

When routing Claude models on Antigravity (such as `ag/claude-opus-4-6-thinking`) via Claude Code or any client sending images, the model fails to read images and responds asking for the file path. Meanwhile, Gemini models and native Antigravity IDE process images without issues.

### Root Cause
1. In `open-sse/translator/request/openai-to-gemini.js`, `wrapInCloudCodeEnvelopeForClaude` only handled `CLAUDE_BLOCK.TEXT`, `CLAUDE_BLOCK.TOOL_USE`, and `CLAUDE_BLOCK.TOOL_RESULT`. Any `CLAUDE_BLOCK.IMAGE` (and `DOCUMENT`) was omitted, sending only text to Google Antigravity's backend.
2. In `open-sse/translator/request/claude-to-openai.js`, `CLAUDE_BLOCK.DOCUMENT` was not converted to `OPENAI_BLOCK.FILE`.
3. In `open-sse/providers/capabilities.js`, `claude-opus-4-6-thinking` and `claude-sonnet-4-6-thinking` were missing from `MODEL_CAPABILITIES` and the `*claude*opus-4-6*` pattern was missing, causing it to fall back to generic budget thinking and a lower context window.

### Changes
- `open-sse/translator/request/openai-to-gemini.js`: Added conversion of `CLAUDE_BLOCK.IMAGE` (base64 `inlineData` & URL `fileData`) and `CLAUDE_BLOCK.DOCUMENT` (base64 `inlineData`) to Gemini Protobuf parts in `wrapInCloudCodeEnvelopeForClaude`.
- `open-sse/translator/request/claude-to-openai.js`: Added support for `CLAUDE_BLOCK.DOCUMENT` converting to `OPENAI_BLOCK.FILE`.
- `open-sse/providers/capabilities.js`: Added `claude-opus-4-6-thinking` and `claude-sonnet-4-6-thinking` to `MODEL_CAPABILITIES` and added matching patterns to `PATTERN_CAPABILITIES`.
- `tests/translator/bugs-antigravity.test.js`: Added regression test verifying image and PDF document blocks properly convert to `inlineData` when translated for Antigravity Claude models.

### Verification

#### 1. Vitest Unit Test
Running `npx vitest run -c tests/vitest.config.js tests/translator/bugs-antigravity.test.js`:
```
 RUN  v3.2.7 ~/VansRouter-main

 ✓ tests/translator/bugs-antigravity.test.js (13 tests) 24ms

 Test Files  1 passed (1)
      Tests  13 passed (13)
   Duration  1.17s
```

#### 2. Translation Output
End-to-end request translation from Claude format containing an image and a PDF document:
```javascript
// Input (Claude format):
{
  model: 'claude-opus-4-6-thinking',
  messages: [{
    role: 'user',
    content: [
      { type: 'text', text: 'explain this image' },
      { type: 'image', source: { type: 'base64', media_type: 'image/png', data: '...' } },
      { type: 'document', source: { type: 'base64', media_type: 'application/pdf', data: '...' } }
    ]
  }]
}

// Output sent to Antigravity v1internal:
parts: [
  { text: 'explain this image' },
  { inlineData: { mimeType: 'image/png', data: '...' } },
  { inlineData: { mimeType: 'application/pdf', data: '...' } }
]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)